### PR TITLE
Fixed bug in Shot.fromTry/Snag.apply, Added tests

### DIFF
--- a/src/main/scala/loamstream/tools/core/CoreStore.scala
+++ b/src/main/scala/loamstream/tools/core/CoreStore.scala
@@ -14,7 +14,7 @@ import loamstream.model.kinds.LKind
   * LoamStream
   * Created by oliverr on 2/16/2016.
   */
-//TODo rename? ConcreteStore?  
+//TODO rename? ConcreteStore?  
 final case class CoreStore(id: LId, spec: StoreSpec) extends Store
 
 object CoreStore {
@@ -27,11 +27,11 @@ object CoreStore {
   
   import Sigs._
   
-  val vcfFile: Store  = {
+  val vcfFile: Store = {
     CoreStore("VCF file", StoreSpec(variantAndSampleToGenotype, StoreKinds.vcfFile))
   }
     
-  val vdsFile: Store  = {
+  val vdsFile: Store = {
     CoreStore("VDS file", StoreSpec(variantAndSampleToGenotype, StoreKinds.vdsFile))
   }
     

--- a/src/main/scala/loamstream/tools/core/CoreToolBox.scala
+++ b/src/main/scala/loamstream/tools/core/CoreToolBox.scala
@@ -63,7 +63,7 @@ object CoreToolBox {
         LoamFileUtils.printToFile(samplesFile.toFile) {
           p => samples.foreach(p.println) // scalastyle:ignore
         }
-        new SimpleSuccess("Extracted sample ids.")
+        SimpleSuccess("Extracted sample ids.")
       }
     }
   }
@@ -87,7 +87,7 @@ object CoreToolBox {
     override def execute(implicit context: ExecutionContext): Future[Result] = {
       Future {
         HailTools.calculateSingletons(importVcfFileJob.vdsFile, singletonsFile)
-        new SimpleSuccess("Calculated singletons from VDS.")
+        SimpleSuccess("Calculated singletons from VDS.")
       }
     }
   }
@@ -107,8 +107,10 @@ object CoreToolBox {
           val samples = vcfParser.samples
           val genotypeToDouble: Genotype => Double = { genotype => VcfUtils.genotypeToAltCount(genotype).toDouble }
           val pcaProjections = pcaProjecter.project(samples, vcfParser.genotypeMapIter, genotypeToDouble)
+          
           KlustaKwikInputWriter.writeFeatures(klustaKwikKonfig, pcaProjections)
-          new SimpleSuccess(s"Wrote PCA projections to file ${klustaKwikKonfig.inputFile}")
+          
+          SimpleSuccess(s"Wrote PCA projections to file ${klustaKwikKonfig.inputFile}")
         }
       }
     }

--- a/src/main/scala/loamstream/util/ShotCombinators.scala
+++ b/src/main/scala/loamstream/util/ShotCombinators.scala
@@ -6,6 +6,8 @@ package loamstream.util
   */
 object ShotCombinators {
 
+  //TODO: TEST! 
+  
   trait ShotsN {
     def and[TN](_n: Shot[TN]): ShotsN
   }

--- a/src/main/scala/loamstream/util/Snag.scala
+++ b/src/main/scala/loamstream/util/Snag.scala
@@ -4,19 +4,7 @@ package loamstream.util
   * LoamStream
   * Created by oliverr on 11/17/2015.
   */
-object Snag {
-  def apply(message: String): Snag = SnagMessage(message)
-
-  def apply(throwable: Throwable): Snag = Snag(throwable)
-
-  def apply(child: Snag, children: Snag*): Snag = SnagSeq(children)
-
-  def apply(message: String, children: Snag*): Snag = SnagTree(message, children)
-
-  def apply(snags: Seq[Snag]): Snag = SnagSeq(snags)
-}
-
-trait Snag {
+sealed trait Snag {
   def message: String
 
   def children: Seq[Snag]
@@ -27,6 +15,18 @@ trait Snag {
       case _ => SnagSeq(Seq(this, snag))
     }
   }
+}
+
+object Snag {
+  def apply(message: String): Snag = SnagMessage(message)
+
+  def apply(throwable: Throwable): Snag = SnagThrowable(throwable)
+
+  def apply(child: Snag, children: Snag*): Snag = SnagSeq(children)
+
+  def apply(message: String, children: Snag*): Snag = SnagTree(message, children)
+
+  def apply(snags: Seq[Snag]): Snag = SnagSeq(snags)
 }
 
 trait SnagLeaf extends Snag {

--- a/src/test/scala/loamstream/apps/minimal/MiniAppEndToEndTest.scala
+++ b/src/test/scala/loamstream/apps/minimal/MiniAppEndToEndTest.scala
@@ -37,7 +37,7 @@ final class MiniAppEndToEndTest extends FunSuite {
 
     val genotypesId = env(LCoreEnv.Keys.genotypesId)
     val pipeline = MiniPipeline(genotypesId)
-    val toolbox = CoreToolBox(env) ++ MiniMockToolBox(env).get
+    val toolbox = CoreToolBox(env)
 
     val genotypesJob = toolbox.createJobs(pipeline.genotypeCallsTool, pipeline)
     

--- a/src/test/scala/loamstream/tools/core/StoreOpsTest.scala
+++ b/src/test/scala/loamstream/tools/core/StoreOpsTest.scala
@@ -1,0 +1,28 @@
+package loamstream.tools.core
+
+import org.scalatest.FunSuite
+
+/**
+ * @author clint
+ * date: Apr 29, 2016
+ */
+final class StoreOpsTest extends FunSuite {
+  test("~>") {
+    import CoreStore._
+    import StoreOps._
+    
+    assert(vcfFile ~> vdsFile === UnarySig(vcfFile, vdsFile))
+    
+    assert(UnarySig(vcfFile, vdsFile).toNarySig === NarySig(Seq(vcfFile), vdsFile))
+        
+    assert((vcfFile, sampleIdsFile) ~> vdsFile === BinarySig((vcfFile, sampleIdsFile), vdsFile))
+    
+    assert(BinarySig((vcfFile, sampleIdsFile), vdsFile).toNarySig === NarySig(Seq(vcfFile, sampleIdsFile), vdsFile))
+    
+    val narySig = NarySig(Seq(vcfFile, sampleIdsFile, singletonsFile), vdsFile)
+    
+    assert(Seq(vcfFile, sampleIdsFile, singletonsFile) ~> vdsFile === narySig)
+    
+    assert(narySig.toNarySig === narySig)
+  }
+}

--- a/src/test/scala/loamstream/util/ShotTest.scala
+++ b/src/test/scala/loamstream/util/ShotTest.scala
@@ -1,0 +1,116 @@
+package loamstream.util
+
+import org.scalatest.FunSuite
+import scala.util.Success
+import scala.util.Try
+import scala.util.Failure
+
+/**
+ * @author clint
+ * date: Apr 29, 2016
+ */
+final class ShotTest extends FunSuite {
+  private val toStr: Int => String = _.toString
+  private val toInt: String => Int = _.toInt
+  private val inc: Int => Int = _ + 1
+    
+  private val hit = Hit(42)
+  
+  private val snag = Snag("foo")
+  
+  private val miss = Miss(snag) 
+
+  private val incAndToString: Int => Shot[String] = i => Hit((i + 1).toString)
+  
+  test("fromTry") {
+    assert(Shot.fromTry(Success(42)) === Hit(42))
+
+    val e = new Exception with scala.util.control.NoStackTrace
+
+    val failure: Try[Int] = Failure(e)
+
+    assert(Shot.fromTry(failure) === Miss(SnagThrowable(e)))
+  }
+
+  test("fromOption") {
+    assert(Shot.fromOption(Some(42), ???) === Hit(42))
+    
+    assert(Shot.fromOption(None, snag) === Miss(snag))
+  }
+  
+  test("get") {
+    assert(hit.get === 42)
+    
+    intercept[NoSuchElementException] {
+      miss.get
+    }
+  }
+  
+  test("map") {
+    assert(hit.map(identity) === hit)
+    
+    assert(hit.map(toStr) === Hit("42"))
+    
+    assert(hit.map(toStr).map(toInt).map(inc) === Hit(43))
+    
+    assert(hit.map(toStr andThen toInt andThen inc) === Hit(43))
+    
+    assert(miss.map(identity) === miss)
+    
+    assert(miss.map(toStr) === miss)
+    
+    assert(miss.map(toStr).map(toInt).map(inc) === miss)
+    
+    assert(miss.map(toStr andThen toInt andThen inc) === miss)
+  }
+  
+  test("flatMap") {
+    assert(hit.flatMap(_ => miss) === miss)
+    assert(miss.flatMap(_ => miss) === miss)
+    
+    assert(hit.flatMap(incAndToString) === Hit("43"))
+    assert(miss.flatMap(incAndToString) === miss)
+  }
+  
+  test("Monad laws") {
+    //Left Identity
+    assert(incAndToString(42) === hit.flatMap(incAndToString))
+
+    //Right identity
+    assert(hit.flatMap(Hit(_)) === hit)
+    
+    //Associativity
+    val f: Int => Shot[Int] = i => Hit(i + 1)
+    val g: Int => Shot[String] = i => Hit(i.toString)
+    
+    assert(hit.flatMap(f).flatMap(g) === hit.flatMap(i => f(i).flatMap(g)))
+  }
+  
+  test("asOpt") {
+    assert(hit.asOpt === Some(42))
+    assert(miss.asOpt === None)
+  }
+  
+  test("orElse") {
+    val hit1 = Hit(42)
+    val hit2 = Hit(99)
+    
+    assert((hit1 orElse hit2) === hit1)
+    assert((hit2 orElse hit1) === hit2)
+    
+    assert((miss orElse hit1) === hit1) 
+  }
+  
+  test("and") {
+    import ShotCombinators._
+    
+    assert((hit and miss) === Shots2(hit, miss))
+    assert((miss and hit) === Shots2(miss, hit))
+    assert((miss and miss) === Shots2(miss, miss))
+    assert((hit and hit) === Shots2(hit, hit))
+  }
+  
+  test("Miss()") {
+    assert(Miss("asdf") === Miss(SnagMessage("asdf")))
+  }
+}


### PR DESCRIPTION
- Fixed  bug in Shot.fromTry/Snag.apply, where calling Snap.apply with a Throwable would cause an infinite loop.
- Added unit tests for Shot and StoreOps. 
- Removed unused MiniMockToolbox reference from MiniAppEndToEndTest
