### PR TITLE
Change to build.sbt to run captureSbtClasspath before running tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,9 +44,10 @@ lazy val commonSettings = Seq(
   captureSbtClasspath := {
     val files: Seq[File] = (fullClasspath in Compile).value.files
     val sbtClasspath: String = files.map(x => x.getAbsolutePath).mkString(File.pathSeparator)
-    println("Set SBT classpath to 'sbt-classpath' environment variable") // scalastyle:ignore
+    println("Set SBT classpath to 'sbt-classpath' JVM system property") // scalastyle:ignore
     System.setProperty("sbt-classpath", sbtClasspath)
   },
+  test <<= (test in Test) dependsOn captureSbtClasspath,
   scalastyleFailOnError := true
 )
 

--- a/src/test/scala/loamstream/compiler/LoamCompilerTest.scala
+++ b/src/test/scala/loamstream/compiler/LoamCompilerTest.scala
@@ -7,15 +7,16 @@ import loamstream.tools.core.LCoreEnv
 import org.scalatest.FunSuite
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import java.io.File
 
 /**
   * LoamStream
   * Created by oliverr on 5/20/2016.
   */
-class LoamCompilerTest extends FunSuite {
+final class LoamCompilerTest extends FunSuite {
   test("Testing compilation of various code fragments (only works after running captureSbtClasspath).") {
     val compiler = new LoamCompiler(OutMessageSink.NoOp)(global)
-    val code =
+    val code = {
       """
     genotypesId := "myImportantGenotypes"
     sampleFilePath := path("/some/path/to/file")
@@ -26,15 +27,41 @@ class LoamCompilerTest extends FunSuite {
     val favoriteSquirrel = Key[Squirrel]("My favourite Squirrel")
     favoriteSquirrel := Squirrel("Tom")
       """
+    }
+    
     val result = compiler.compile(code)
-    assert(result.errors.isEmpty)
-    assert(result.warnings.isEmpty)
-    assert(result.envOpt.nonEmpty)
+    
+    assert(result.errors == Nil)   //NB: Compare with Nil for better failure messages
+    assert(result.warnings == Nil) //NB: Compare with Nil for better failure messages
+    
     val env = result.envOpt.get
+    
     assert(env(LCoreEnv.Keys.genotypesId) === "myImportantGenotypes")
     assert(env(LCoreEnv.Keys.sampleFilePath)() === Paths.get("/some/path/to/file"))
     assert(env.get(LCoreEnv.Keys.pcaProjectionsFilePath).nonEmpty)
     assert(env.get(LCoreEnv.Keys.klustaKwikKonfig).nonEmpty)
     assert(env.size === 5)
+  }
+  
+  test("mungeClassPath()") {
+    val sep = File.pathSeparator
+    
+    import LoamCompiler.{mungeClassPath, sbtClasspathSysPropKey}
+    
+    intercept[Exception] {
+      mungeClassPath(null)
+    }
+    
+    intercept[Exception] {
+      mungeClassPath("")
+    }
+    
+    intercept[Exception] {
+      mungeClassPath("  ")
+    }
+    
+    assert(mungeClassPath(".") == s".${sep}.")
+    assert(mungeClassPath("foo") == s".${sep}foo")
+    assert(mungeClassPath("foo:foo/bar:baz/blerg/x.jar") == s".${sep}foo:foo/bar:baz/blerg/x.jar")
   }
 }


### PR DESCRIPTION
- Change to build.sbt to run `captureSbtClasspath` before running tests.
- Factored out and tested classpath-munging code.

This gets `LoamCompilerTest` running in SBT without any hassle or extra commands.  Unfortunately, `LoamCompilerTest` still can't run in IntelliJ or Eclipse.
