### PR TITLE
Swap in RxScala for Monix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,9 +10,9 @@ lazy val Versions = new {
   val Scala = "2.11.8"
   val ScalaTest = "3.0.0"
   val TypesafeConfig = "1.3.0"
-  val Monix = "2.0-RC9"
   val Slick = "3.1.1"
   val H2 = "1.4.192"
+  val RxScala = "0.26.2"
 }
 
 lazy val mainDeps = Seq(
@@ -25,7 +25,7 @@ lazy val mainDeps = Seq(
   "us.levk" % "drmaa-gridengine" % Versions.DrmaaGridEngine,
   "ch.qos.logback" % "logback-classic" % Versions.LogBack,
   "com.typesafe" % "config" % Versions.TypesafeConfig,
-  "io.monix" %% "monix" % Versions.Monix,
+  "io.reactivex" %% "rxscala" % Versions.RxScala,
   "com.typesafe.slick" %% "slick" % Versions.Slick,
   "com.h2database" % "h2" % Versions.H2
 )

--- a/src/main/scala/loamstream/util/ObservableEnrichments.scala
+++ b/src/main/scala/loamstream/util/ObservableEnrichments.scala
@@ -1,87 +1,118 @@
 package loamstream.util
 
-import monix.reactive.Observable
-import monix.execution.Scheduler
-import monix.reactive.OverflowStrategy
-import monix.execution.Cancelable
+import scala.concurrent.Future
+import scala.concurrent.Promise
+import scala.util.Failure
+import scala.util.Success
+
+import rx.lang.scala.Observable
 
 /**
  * @author clint
  * date: Jul 1, 2016
- * 
+ *
  * Extension methods for Monix Observables.  Adds combinators that make some LoamStream use cases easier.
  */
 object ObservableEnrichments {
   final implicit class ObservableOps[A](val obs: Observable[A]) extends AnyVal {
     /**
      * Returns an Observable that emits elements that satisfy the passed-in predicate, up to and including the FIRST
-     * element that does not satisy the predicate.  The returned observable completes after emitting the first element 
+     * element that does not satisy the predicate.  The returned observable completes after emitting the first element
      * that satisfies the predicate.
-     * 
+     *
      * For example, for a well-behaved Uger job, say we have
-     * 
+     *
      * val statuses: Obervable[JobStatus] = ... // monitor some job
-     * 
+     *
      * statuses.until(_.isFinished)
-     * 
+     *
      * will produce an Observable that will emit elements like
-     * 
+     *
      * JobStatus.Queued, JobStatus.Running, JobStatus.Running, ... , JobStatus.Done
-     * 
+     *
      * Or suppose we had
-     * 
+     *
      * val numbers = Observable(1,2,3,4,5,6,7,8,9,10) //an Observable that emits the elements passed to apply()
-     * 
+     *
      * numbers.until(_ >= 6)
-     * 
-     * Would produce an Observable that yields 
-     * 
+     *
+     * Would produce an Observable that yields
+     *
      * 1,2,3,4,5,6
-     * 
+     *
      * Note that this is different from the built-in .takeWhile, which returns elements that satisfy a predicate, BUT
      * NOT any that don't.
-     * 
-     * numbers.takeWhile(_ < 6) 
-     * 
+     *
+     * numbers.takeWhile(_ < 6)
+     *
      * would return an Observable that yields
-     * 
+     *
      * 1,2,3,4,5
-     * 
-     * or for the job example, 
-     * 
+     *
+     * or for the job example,
+     *
      * statuses.takeWhile(_.notFinished)
-     * 
+     *
      * would return an Observable that might yield
-     * 
+     *
      * JobStatus.Queued, JobStatus.Running, ..., JobStatus.Running
-     * 
+     *
      * (Note the missing 'terminal' status.)
-     * 
+     *
      * @param p the predicate to use to decide what events to emit
      * @return an Observable that emits elements that satisfy the passed-in predicate, up to and including the FIRST
      * element that does not satisy the predicate.
-     * 
+     *
      * NB: Note that this was renamed to 'until' from 'takeUntil'.  The latter would be preferrable, but it conflicts
-     * with a new method in Monix proper.
+     * with a method in RxScala proper.
      */
-    def until(p: A => Boolean)(implicit scheduler: Scheduler): Observable[A] = {
-      //TODO: Revisit Overflow Strategy
-      Observable.create(OverflowStrategy.Unbounded) { downstream =>
-        def complete() = downstream.onComplete()
-        
-        val cancelable = obs.foreach { a =>
-          downstream.onNext(a)
-          
-          if(p(a)) {
-            complete()
-          } 
+    def until(p: A => Boolean): Observable[A] = {
+      Observable { subscriber =>
+        def onNext(a: A): Unit = {
+          subscriber.onNext(a)
+
+          if (p(a)) {
+            subscriber.onCompleted()
+          }
         }
-        
-        //TODO: There must be a better way.
-        cancelable.foreach(_ => complete())
-        
-        cancelable
+
+        obs.foreach(onNext, subscriber.onError, subscriber.onCompleted)
       }
+    }
+
+    /**
+     * Returns a Future that will contain the FIRST value fired from the wrapped Observable.
+     *
+     * If the wrapped Observable is empty, the returned Future will be completed with a Failure.
+     */
+    def firstAsFuture: Future[A] = asFuture(obs.headOption)
+
+    /**
+     * Returns a Future that will contain the LAST value fired from the wrapped Observable.
+     *
+     * Note that the returned Future will ONLY complete if the wrapped Observable does.
+     *
+     * If the wrapped Observable is empty, the returned Future will be completed with a Failure.
+     */
+    def lastAsFuture: Future[A] = asFuture(obs.lastOption)
+
+    private def asFuture(o: Observable[Option[A]]): Future[A] = {
+      val p: Promise[A] = Promise()
+
+      def completeDueToNoValue(): Unit = p.complete(Tries.failure("Observable emitted no values"))
+
+      def onNext(o: Option[A]): Unit = o match {
+        case Some(a) => p.complete(Success(a))
+        case None    => completeDueToNoValue()
+      }
+
+      def onError(e: Throwable): Unit = p.complete(Failure(e))
+
+      def onCompleted(): Unit = completeDueToNoValue()
+
+      o.first.foreach(onNext, onError/*, onCompleted*/)
+
+      p.future
     }
   }
 }

--- a/src/test/scala/loamstream/uger/JobsTest.scala
+++ b/src/test/scala/loamstream/uger/JobsTest.scala
@@ -7,9 +7,9 @@ import scala.collection.mutable.Buffer
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.duration.Duration
 import scala.concurrent.Await
-import monix.execution.Scheduler
 
 import scala.collection.mutable
+import loamstream.util.ObservableEnrichments
 
 /**
  * @author clint
@@ -19,9 +19,10 @@ final class JobsTest extends FunSuite {
   test("monitor() - happy path") {
     import JobStatus._
     
-    implicit val scheduler = Scheduler.singleThread("monixScheduler")
-    
     val client = MockDrmaaClient(Success(Queued), Success(Running), Success(Done))
+    
+    import scala.concurrent.ExecutionContext.Implicits.global
+    import ObservableEnrichments._
     
     val poller = Poller.drmaa(client)
     
@@ -29,13 +30,9 @@ final class JobsTest extends FunSuite {
     
     val statuses = Jobs.monitor(poller, 2)(jobId)
     
-    val buf: mutable.Buffer[JobStatus] = new ArrayBuffer
-    
-    val fut = statuses.foreach(buf += _)
+    val fut = statuses.to[Seq].firstAsFuture
 
-    Await.ready(fut, Duration.Inf)
-    
-    assert(buf == Seq(Queued, Running, Done))
+    assert(Await.result(fut, Duration.Inf) == Seq(Queued, Running, Done))
     
     import scala.concurrent.duration._
     


### PR DESCRIPTION
Since it seems like one way or another, the `RxExecuter` work will use RxScala, and RxScala is a bit friendlier as well as battle-tested (it wraps RxJava, which runs Netflix), replace Monix with RxScala.
