### PR TITLE
Fix command line jobs

### DIFF
--- a/src/main/scala/loamstream/model/jobs/commandline/CommandLineStringJob.scala
+++ b/src/main/scala/loamstream/model/jobs/commandline/CommandLineStringJob.scala
@@ -26,7 +26,7 @@ final case class CommandLineStringJob(
   override def processBuilder: ProcessBuilder = {
     val commandLineEncoded = Matcher.quoteReplacement(commandLineString)
     val commandLineEncodedEncoded = Matcher.quoteReplacement(commandLineEncoded)
-    Process(Seq("bash", "-c", commandLineEncodedEncoded), workDir.toFile)
+    Process(Seq("sh", "-c", commandLineEncodedEncoded), workDir.toFile)
   }
 
   override protected def doWithInputs(newInputs: Set[LJob]): LJob = copy(inputs = newInputs)


### PR DESCRIPTION
Two changes to make command line jobs run:

First, replaces "/bin/bash" by "bash". I'm sure you all have bash on your PATH. 

Second, it turns out that when using ProcessBuilder, somehow Strings get decoded - twice - in terms of backslashes and dollars. So, to get a \ or $ to bash, you have to give it to the ProcessBuilder as \\\\ and \\\$. I don't know why that is so, but I can confirm that it is so.