### PR TITLE
Cg log skipped jobs

### DIFF
--- a/src/main/scala/loamstream/model/execute/RxExecuter.scala
+++ b/src/main/scala/loamstream/model/execute/RxExecuter.scala
@@ -93,7 +93,7 @@ final case class RxExecuter(
   }
   
   private def logSkippedJobs(skippedJobs: Set[LJob]): Unit = {
-    info(s"Skipping (${skippedJobs.size} jobs:)")
+    info(s"Skipping (${skippedJobs.size}) jobs:")
     
     skippedJobs.foreach(job => info(s"Skipped: $job"))
   }


### PR DESCRIPTION
Better logging in `RxExecuter`.  Skipped jobs are logged at info level, and some methods were extracted.