### PR TITLE
Rk sample sharing fix

### DIFF
--- a/pipeline/r_scripts/calc_kinship_sample_sharing.r
+++ b/pipeline/r_scripts/calc_kinship_sample_sharing.r
@@ -1,9 +1,10 @@
 args<-commandArgs(trailingOnly=T)
-x<-try(read.table(args[1],header=T,as.is=T,stringsAsFactors=F))
-if(inherits(x, "try-error"))
+x<-try(read.table(args[1],header=T,as.is=T,stringsAsFactors=F), silent=TRUE)
+if(inherits(x, "try-error")) {
 	file.create(args[2])
-else
+} else {
 	ids<-c(x$ID1,x$ID2)
 	out<-as.data.frame(sort(table(ids),decreasing=T))
 	names(out)[1]<-"ibd_pairs"
 	write.table(out,args[2],row.names=T,col.names=F,quote=F,append=F,sep="\t")
+}


### PR DESCRIPTION
Added a try statement to the calc_sample_sharing.r script, allowing for an empty or missing '.kin0.related' file