### PR TITLE
Remove unused stores; add missing asInput.

### DIFF
--- a/pipeline/loam/input.loam
+++ b/pipeline/loam/input.loam
@@ -24,7 +24,10 @@ val inKG_V3_5K_PCA_SCORES = store[TXT].at("/humgen/diabetes/users/ryank/data/1kg
 val inKG_V3_5K_PCA_LOADINGS = store[TXT].at("/humgen/diabetes/users/ryank/data/1kg_phase3/1000GP_Phase3_vcf_purcell5k/pca.loadings.tsv").asInput
 
 /** Hail VDS input */
-val inKG_HAIL = store[TXT].at("/humgen/diabetes/users/ryank/data/1kg_phase3/1000GP_Phase3_vcf_purcell5k/ALL.purcell5k.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vds")
+val inKG_HAIL =
+  store[TXT]
+  .at("/humgen/diabetes/users/ryank/data/1kg_phase3/1000GP_Phase3_vcf_purcell5k/ALL.purcell5k.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vds")
+  .asInput
 
 /**
  * 1KG VCF base name (excluding .vcf.gz)

--- a/pipeline/loam/qc.loam
+++ b/pipeline/loam/qc.loam
@@ -121,9 +121,6 @@ object Google {
   val FOR_QC_PRUNE_OUT = store[TXT].at(out / s"${Common.FOR_QC_NAME}.prune.out")
 
   // Chunk #2
-  val inKG_HAIL = store[TXT].at(data / "inkg_hail.vds")
-  val inKG_V3_5K_AF = store[TXT].at(data / "allele_frequencies.tsv")
-
   val ANCESTRYPCA_SCORES_TSV = store[TXT].at(out / s"${outLABEL}.ancestry.pca.scores.tsv")
   val ANCESTRYPCA_LOADINGS_TSV = store[TXT].at(out / s"${outLABEL}.ancestry.pca.loadings.tsv")
 
@@ -329,8 +326,8 @@ uger {
   */
 
 local {
-  googleCopy(input.inKG_HAIL, Google.inKG_HAIL, "-r")
-  googleCopy(input.inKG_V3_5K_AF, Google.inKG_V3_5K_AF)
+  googleCopy(inKG_HAIL, Google.inKG_HAIL, "-r")
+  googleCopy(inKG_V3_5K_AF, Google.inKG_V3_5K_AF)
 }
 
 google {


### PR DESCRIPTION
Remove unused stores; add missing asInput. Hopefully, the missing asInput is the cause why some commands never get skipped.