### PR TITLE
Report correct metric for UGER job memory utilization

### DIFF
--- a/src/main/scala/loamstream/db/slick/ResourceRow.scala
+++ b/src/main/scala/loamstream/db/slick/ResourceRow.scala
@@ -25,7 +25,7 @@ object ResourceRow {
       LocalResourceRow(executionId, Timestamp.from(startTime), Timestamp.from(endTime))
     }
     case UgerResources(mem, cpu, node, queue, startTime, endTime) => {
-      UgerResourceRow(executionId, mem.gb, cpu.seconds, node, queue.map(_.name),
+      UgerResourceRow(executionId, mem.kb, cpu.seconds, node, queue.map(_.name),
         Timestamp.from(startTime), Timestamp.from(endTime))
     }
     case GoogleResources(cluster, startTime, endTime) => {
@@ -59,7 +59,7 @@ final case class UgerResourceRow(executionId: Int,
     import scala.concurrent.duration._
     
     UgerResources(
-        Memory.inGb(mem), CpuTime(cpu.seconds), node, 
+        Memory.inKb(mem), CpuTime(cpu.seconds), node,
         queue.flatMap(Queue.fromString), startTime.toInstant, endTime.toInstant)
   }
   

--- a/src/main/scala/loamstream/model/execute/Memory.scala
+++ b/src/main/scala/loamstream/model/execute/Memory.scala
@@ -33,5 +33,7 @@ object Memory {
   
   def inBytes(howMany: Long): Memory = Memory(byte * howMany)
   
+  def inKb(howMany: Double): Memory = Memory(kilobyte * howMany)
+
   def inGb(howMany: Double): Memory = Memory(gigabyte * howMany)
 }

--- a/src/main/scala/loamstream/model/execute/Resources.scala
+++ b/src/main/scala/loamstream/model/execute/Resources.scala
@@ -61,7 +61,7 @@ object Resources {
   object UgerResources {
     object Keys {
       val cpu = "cpu"
-      val mem = "mem"
+      val mem = "ru_maxrss"
       val startTime = "start_time"
       val endTime = "end_time"
     }
@@ -85,8 +85,11 @@ object Resources {
       
       //NB: Uger reports cpu time as a floating-point number of cpu-seconds. 
       def toCpuTime(s: String) = CpuTime(s.toDouble.seconds)
-      //NB: Uger reports memory used as a floating-point number of gigabytes.
-      def toMemory(s: String) = Memory.inGb(s.toDouble)
+
+      //NB: The value of qacct's ru_maxrss field (in kilobytes) is the closest approximation of
+      //a Uger job's memory utilization
+      def toMemory(s: String) = Memory.inKb(s.toDouble)
+
       //NB: Uger returns times as floating-point numbers of milliseconds since the epoch, but the values
       //always represent integers, like '1488840586288.0000'. (Note the trailing .0000)
       //So we convert to a double first, then to a long, to drop the superfluous fractional part.

--- a/src/test/scala/loamstream/model/execute/UgerResourcesTest.scala
+++ b/src/test/scala/loamstream/model/execute/UgerResourcesTest.scala
@@ -99,7 +99,7 @@ final class UgerResourcesTest extends FunSuite {
     val r = fromMap(realWorldMap).get
     
     assert(r.cpuTime === CpuTime(1.9867.seconds))
-    assert(r.memory === Memory.inGb(0.0141))
+    assert(r.memory === Memory.inKb(54328))
     assert(r.node === None)
     assert(r.queue === None)
     assert(r.startTime === Instant.ofEpochMilli(1488840619845L))

--- a/src/test/scala/loamstream/uger/Drmaa1ClientTest.scala
+++ b/src/test/scala/loamstream/uger/Drmaa1ClientTest.scala
@@ -28,7 +28,7 @@ final class Drmaa1ClientTest extends FunSuite {
     import scala.concurrent.duration._
     
     assert(r.cpuTime === CpuTime(1.9867.seconds))
-    assert(r.memory === Memory.inGb(0.0141))
+    assert(r.memory === Memory.inKb(54328))
     assert(r.node === None)
     assert(r.queue === None)
     assert(r.startTime === Instant.ofEpochMilli(1488840619845L))


### PR DESCRIPTION
`ru_maxrss` (in kilobytes) on the output of `qacct` is the correct metric for memory utilization of a UGER job so use that instead of `mem`.

Changes verified via a UGER run.