### PR TITLE
Integration-test fixes

### DIFF
--- a/src/it/scala/loamstream/AnalysisPipelineEndToEndTest.scala
+++ b/src/it/scala/loamstream/AnalysisPipelineEndToEndTest.scala
@@ -2,23 +2,22 @@ package loamstream
 
 import java.nio.file.Path
 
-import loamstream.util.Files
 import org.scalatest.FunSuite
+
+import loamstream.util.Files
 
 /**
  * @author kyuksel
  *         date: 7/24/17
  */
 final class AnalysisPipelineEndToEndTest extends FunSuite {
-  private val outputDir = TestHelpers.path("./analysis")
+  import IntegrationTestHelpers.{ path, withLoudStackTraces }
+  
+  private val outputDir = path("./analysis")
 
   test("Run the analysis pipeline end-to-end on CAMP data") {
-    try {
+    withLoudStackTraces {
       run()
-    } catch {
-      //NB: SBT drastically truncates stack traces. so print them manually to get more info.  
-      //This workaround is lame, but gives us a chance at debugging failures.
-      case e: Throwable => e.printStackTrace() ; throw e
     }
 
     val regionsFileNameRegex = "chr.*regions"
@@ -35,7 +34,7 @@ final class AnalysisPipelineEndToEndTest extends FunSuite {
   private def run(): Unit = {
     Files.createDirsIfNecessary(outputDir)
 
-    Files.createDirsIfNecessary(TestHelpers.path("./uger"))
+    Files.createDirsIfNecessary(path("./uger"))
 
     val args: Array[String] = {
       Array(

--- a/src/it/scala/loamstream/IntegrationTestHelpers.scala
+++ b/src/it/scala/loamstream/IntegrationTestHelpers.scala
@@ -1,0 +1,20 @@
+package loamstream
+
+import java.nio.file.Path
+import java.nio.file.Paths
+
+/**
+ * @author clint
+ * Jul 27, 2017
+ */
+object IntegrationTestHelpers {
+  def path(s: String): Path = Paths.get(s)
+  
+  def withLoudStackTraces[A](f: => A): A = {
+    try { f } catch {
+      //NB: SBT drastically truncates stack traces. so print them manually to get more info.  
+      //This workaround is lame, but gives us a chance at debugging failures.
+      case e: Throwable => e.printStackTrace() ; throw e
+    }
+  }
+}

--- a/src/it/scala/loamstream/QcPipelineEndToEndTest.scala
+++ b/src/it/scala/loamstream/QcPipelineEndToEndTest.scala
@@ -1,9 +1,10 @@
 package loamstream
 
-import org.scalatest.FunSuite
 import java.nio.file.Path
+
+import org.scalatest.FunSuite
+
 import loamstream.util.ExitCodes
-import java.nio.file.Paths
 import loamstream.util.Files
 
 /**
@@ -11,16 +12,14 @@ import loamstream.util.Files
  * Apr 21, 2017
  */
 final class QcPipelineEndToEndTest extends FunSuite {
+  import IntegrationTestHelpers.{ path, withLoudStackTraces }
+  
   private val referenceDir = path("/humgen/diabetes/users/dig/loamstream/ci/test-data/qc/camp/results")
   private val outputDir = path("./qc")
 
   test("Run the QC pipeline end-to-end on real data") {
-    try {
+    withLoudStackTraces {
       run()
-    } catch {
-      //NB: SBT drastically truncates stack traces. so print them manually to get more info.  
-      //This workaround is lame, but gives us a chance at debugging failures.
-      case e: Throwable => e.printStackTrace() ; throw e
     }
 
     //NB: Deterministic outputs from the penultimate Klustaskwik jobs
@@ -62,8 +61,6 @@ final class QcPipelineEndToEndTest extends FunSuite {
 
     pairsToCompare.foreach(diff.tupled)
   }
-
-  private def path(s: String): Path = Paths.get(s)
 
   private def run(): Unit = {
     Files.createDirsIfNecessary(outputDir)


### PR DESCRIPTION
Add IntegrationTestHelpers.path, since test-scoped helper code isn't available; add withLoudStackTraces to factor out some integration-specific exception handling