### PR TITLE
Upgrade to SBT 1.0.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -74,15 +74,6 @@ lazy val root = (project in file("."))
     mainClass in Compile := Some("loamstream.apps.Main")
   ).enablePlugins(JavaAppPackaging)
 
-lazy val webui = (project in file("webui"))
-  .dependsOn(root)
-  .configs(IntegrationTest)
-  .enablePlugins(PlayScala)
-  .settings(commonSettings: _*)
-  .settings(
-    name := "LoamStream WebUI"
-  )
-
 enablePlugins(GitVersioning)
 
 scalastyleConfig in Test := file("scalastyle-config-for-tests.xml")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,12 +1,13 @@
+// Plug-in availability statuses for SBT 1.x migration are listed at:
+// https://github.com/sbt/sbt/wiki/sbt-1.x-plugin-migration
+
 resolvers += "Typesafe repository" at "https://dl.bintray.com/typesafe/maven-releases/"
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.1.1")
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.2.2")
 
-addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.9.0")
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")
-
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.5")
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")
 


### PR DESCRIPTION
Faster incremental compilation among [other benefits](http://developer.lightbend.com/blog/2017-08-11-sbt-1-0-0/#headline-features)

Removed the WebUI build (which, to my knowledge, hasn't been used for over a year) that depended on `Play` which doesn't have a plug-in support for `SBT 1.x` yet.

Based on an integration-test run (with `hang-test-branch` build), the changes are backwards-compatible with `SBT 0.13.13`. Another run with `qc-pipeline-branch` build is underway.