### PR TITLE
Misc Improvements that came out of Ryan's METSIM analysis work

### DIFF
--- a/src/main/scala/loamstream/apps/LoamRunner.scala
+++ b/src/main/scala/loamstream/apps/LoamRunner.scala
@@ -1,13 +1,17 @@
 package loamstream.apps
 
+import scala.util.control.NonFatal
+
+import loamstream.compiler.GraphSource
+import loamstream.compiler.GraphThunk
 import loamstream.compiler.LoamCompiler
 import loamstream.compiler.LoamEngine
 import loamstream.compiler.LoamProject
+import loamstream.loam.LoamGraph
+import loamstream.model.Tool
 import loamstream.model.jobs.Execution
 import loamstream.model.jobs.LJob
 import loamstream.util.Loggable
-import loamstream.compiler.GraphSource
-import loamstream.model.Tool
 
 /**
  * @author clint
@@ -53,13 +57,21 @@ object LoamRunner {
       //Keep track of job-execution results and the tools we've run "so far"
       val z: (Map[LJob, Execution], Set[Tool]) = (emptyJobResults, Set.empty)
       
+      debug("Processing graph chunks")
+      
       //Fold over the "stream" of graph chunks, producing job-execution results
       val (jobResults, _) = graphSource.iterator.foldLeft(z) { (state, chunk) =>
         val (jobResultsSoFar, toolsRunSoFar) = state
         
+        val rawChunkGraph = getGraphFrom(chunk)
+        
+        debug(s"Made raw chunk graph with ${rawChunkGraph.tools.size} tools and ${rawChunkGraph.stores.size} stores.")
+        
         //Filter out tools from previous chunks, so we don't run jobs more than necessary, saving
         //the expense of calculating if a job can be skipped.
-        val chunkGraph = chunk().without(toolsRunSoFar)
+        val chunkGraph = rawChunkGraph.without(toolsRunSoFar)
+
+        debug(s"Made filtered chunk graph with ${chunkGraph.tools.size} tools and ${chunkGraph.stores.size} stores.")
         
         //Skip running if there are no new tools
         val jobResults = {
@@ -71,6 +83,17 @@ object LoamRunner {
       }
       
       jobResults
+    }
+    
+    private def getGraphFrom(thunk: GraphThunk): LoamGraph = {
+      try { thunk() }
+      catch {
+        case NonFatal(e) => {
+          error(s"Evaluating loam code chunk threw exception: $e", e)
+          
+          throw e
+        }
+      }
     }
   }
 }

--- a/src/main/scala/loamstream/compiler/GraphQueue.scala
+++ b/src/main/scala/loamstream/compiler/GraphQueue.scala
@@ -1,23 +1,34 @@
 package loamstream.compiler
 
 import scala.collection.mutable.Queue
+import loamstream.util.Loggable
 
 /**
  * @author clint
  * Jul 10, 2017
  */
-final class GraphQueue {
+final class GraphQueue extends Loggable {
   private[this] val lock = new AnyRef
   
   private[this] val queue: Queue[GraphThunk] = Queue.empty
   
+  private[compiler] def size: Int = queue.size
+  
   def enqueue(graphHandle: GraphThunk): this.type = lock.synchronized {
+    trace("Enqueueing graph thunk")
+    
     queue.enqueue(graphHandle)
     
     this
   }
   
-  def dequeue(): GraphThunk = lock.synchronized { queue.dequeue() }
+  def dequeue(): GraphThunk = lock.synchronized { 
+    val result = queue.dequeue()
+    
+    trace(s"Dequeued graph thunk; queue ${if(isEmpty) "EMPTY" else "NOT Empty"} afterwards")
+    
+    result
+  }
   
   def isEmpty: Boolean = lock.synchronized { queue.isEmpty }
   

--- a/src/main/scala/loamstream/compiler/LoamCompiler.scala
+++ b/src/main/scala/loamstream/compiler/LoamCompiler.scala
@@ -280,6 +280,8 @@ final class LoamCompiler(settings: LoamCompiler.Settings = LoamCompiler.Settings
           
           projectContext.registerGraphSoFar()
           
+          debug(s"Compilation finished, starting with ${projectContext.graphQueue.size} graph chunks.")
+          
           LoamCompiler.Result.success(reporter, projectContext)
         } else {
           error(s"Compilation failed. There were $soManyIssues.")

--- a/src/main/scala/loamstream/model/jobs/LJob.scala
+++ b/src/main/scala/loamstream/model/jobs/LJob.scala
@@ -36,7 +36,7 @@ trait LJob extends Loggable {
   private def snapshot: JobSnapshot = snapshotRef()
   
   //NB: Needs to be a ReplaySubject for correct operation
-  private[this] val runsEmitter: Subject[JobRun] = ReplaySubject.withSize(15)
+  private[this] val runsEmitter: Subject[JobRun] = ReplaySubject.withSize(15) //scalastyle:ignore magic.number
   
   /**
    * An Observable that emits JobRuns of this job.  These are (effectively) tuples of (job, status, runCount), 

--- a/src/test/scala/loamstream/apps/LoamRunnerTest.scala
+++ b/src/test/scala/loamstream/apps/LoamRunnerTest.scala
@@ -14,6 +14,7 @@ import loamstream.compiler.LoamEngine
 import loamstream.loam.LoamScript
 import java.nio.file.Path
 import loamstream.util.PathEnrichments
+import loamstream.util.Files
 
 /**
  * @author clint
@@ -33,6 +34,49 @@ final class LoamRunnerTest extends FunSuite {
       Code.oneAndThen(workDir))
   }
   
+  test("dynamic execution - andThen throws") {
+    val workDir = path("target/MainTest")
+    val code = Code.oneAndThenThatThrows(workDir)
+    
+    nukeAndRemake(workDir)
+    
+    import TestHelpers.config
+    
+    val loamEngine: LoamEngine = LoamEngine.default(config)
+    
+    @volatile var timesShutdown: Int = 0
+    @volatile var timesCompiled: Int = 0
+    
+    def noopShutdown[A]: ( => A) => A = incAfter(timesShutdown += 1) { f => f }
+    
+    val compile: LoamProject => LoamCompiler.Result = incAfter(timesCompiled += 1)(loamEngine.compile)
+   
+    val loamRunner = LoamRunner(loamEngine, compile, noopShutdown)
+
+    val project = LoamProject(config, LoamScript.withGeneratedName(code))
+    
+    assert(timesShutdown === 0)
+    assert(timesCompiled === 0)
+    
+    val thrown = intercept[Exception] {
+      loamRunner.run(project)
+    }
+    
+    assert(timesShutdown === 1)
+    assert(timesCompiled === 1)
+    
+    assert(thrown.getMessage === "blerg")
+    
+    //assert that commands before the andThen ran
+    val lastStoreWrittenTo = workDir / "storeInitial.txt"
+    
+    val expectedLines = Seq("line1", "line2", "line3")
+    
+    val actualLines = Files.getLines(lastStoreWrittenTo).map(_.trim)
+    
+    assert(actualLines === expectedLines)
+  }
+  
   test("dynamic execution - multiple top-level andThens") {
     val workDir = path("target/MainTest2")
     
@@ -44,6 +88,7 @@ final class LoamRunnerTest extends FunSuite {
   }
   
   private def doTest(dir: Path, finalOutputFile: Path, expectedContents: String, code: String): Unit = {
+    
     nukeAndRemake(dir)
     
     import TestHelpers.config
@@ -121,6 +166,25 @@ andThen {
   }
   
   cmd"cat ${workDir}/store?.txt > ${storeFinal}".in(stores).out(storeFinal)
+}
+"""
+
+def oneAndThenThatThrows(dir: Path): String = """
+import scala.collection.mutable.{Buffer, ArrayBuffer}
+import loamstream.model.Store
+import loamstream.util.Files
+
+val workDir = path("""" + dir + """")
+
+val storeInitial = store[TXT].at(workDir / "storeInitial.txt")
+val storeFinal = store[TXT].at(workDir / "storeFinal.txt")
+
+def createStore(i: Int): Store[TXT] = store[TXT].at(workDir / s"store$i.txt")
+
+cmd"printf 'line1\nline2\nline3\n' > $storeInitial".out(storeInitial)
+
+andThen {
+  throw new Exception("blerg")
 }
 """
 

--- a/src/test/scala/loamstream/compiler/GraphSplittingTest.scala
+++ b/src/test/scala/loamstream/compiler/GraphSplittingTest.scala
@@ -501,6 +501,69 @@ final class GraphSplittingTest extends FunSuite with Loggable {
     }
   }
   
+  test("one andThen, at the end, but it throws") {
+    val code = """
+      val store0 = store[TXT].at("store0.txt").asInput
+      val store1 = store[TXT].at("store1.txt")
+      val store2 = store[TXT].at("store2.txt")
+      
+      cmd"foo -i $store0 -o $store1".in(store0).out(store1)
+      
+      andThen {
+        throw new Exception("blerg")
+      }
+      """
+    
+    val chunkThunks = chunksFrom(code).toVector
+    
+    //We should still get 3 chunks
+    assert(chunkThunks.size === 3)
+    
+    val Seq(thunk0, thunk1, thunk2) = chunkThunks
+    
+    assert(thunk0() eq thunk0())
+    
+    {
+      val graph0 = thunk0()
+      
+      assert(graph0.stores.size === 3)
+      
+      assertStoreExists(graph0)("./store0.txt")
+      assertStoreExists(graph0)("./store1.txt")
+      assertStoreExists(graph0)("./store2.txt")
+      
+      assert(graph0.tools.size === 1)
+      
+      assertCommandExists(graph0)("foo -i ./store0.txt -o ./store1.txt")
+      
+      val store0 = findStore(graph0)("./store0.txt")
+      val store1 = findStore(graph0)("./store1.txt")
+      val store2 = findStore(graph0)("./store2.txt")
+      
+      val cmd0 = findCommand(graph0)("foo -i ./store0.txt -o ./store1.txt")
+      
+      assert(inputs(graph0)(cmd0) === Set[Store.Untyped](store0))
+      
+      assert(outputs(graph0)(cmd0) === Set[Store.Untyped](store1))
+    }
+    
+    {
+      val caught = intercept[Exception] {
+        thunk1()
+      }
+      
+      assert(caught.getMessage === "blerg")
+    }
+    
+    //Final graph should have no new tools
+    
+    val graph2 = thunk2()
+    
+    val filteredGraph2 = graph2.without(thunk0().tools)
+    
+    assert(filteredGraph2.tools === Set.empty)
+  }
+  
   private def chunksFrom(code: String): Iterator[GraphThunk] = {
     val project = LoamProject(config, LoamScript("foo", code))
     

--- a/src/test/scala/loamstream/loam/LanguageSupportTest.scala
+++ b/src/test/scala/loamstream/loam/LanguageSupportTest.scala
@@ -82,7 +82,8 @@ def greet(name):
   print 'Hello', name
 
 greet('Alice')
-greet('Bob')"""
+greet('Bob')
+"""
 
     doTest(loamLines, expectedBinary, expectedScriptContent)
   }
@@ -143,7 +144,8 @@ if(inherits(x, "try-error")) {
   out<-as.data.frame(sort(table(ids),decreasing=T))
   names(out)[1]<-"ibd_pairs"
   write.table(out,args[2],row.names=T,col.names=F,quote=F,append=F,sep="\t")
-}"""
+}
+"""
 
     doTest(loamLines, expectedBinary, expectedScriptContent)
   }


### PR DESCRIPTION
- Make sure exceptions thrown by evaluating graph thunks in `LoamRunner` are at least logged
- Added tests for the current behavior when exceptions are thrown by code in `andThen` blocks
- Added `getLines` and `getNonEmptyLines` to `loamstream.util.Files` (to replace fragile code in some .loam files)
- made `Files.readFrom` and `Files.readFromAsUtf8` work the same (they previously both used the UTF-8 encoding, but had different behavior regarding line endings).