### PR TITLE
No longer wait forever for async ops in tests

### DIFF
--- a/src/main/scala/loamstream/db/slick/CommonDaoOps.scala
+++ b/src/main/scala/loamstream/db/slick/CommonDaoOps.scala
@@ -1,9 +1,12 @@
 package loamstream.db.slick
 
-import slick.jdbc.JdbcProfile
-import loamstream.util.Loggable
-import loamstream.util.Futures
+import scala.concurrent.Await
 import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.duration.Duration
+
+import loamstream.util.Loggable
+import slick.jdbc.JdbcProfile
 
 /**
  * @author clint
@@ -11,20 +14,18 @@ import scala.concurrent.ExecutionContext
  * 
  * NB: Factored out of SlickLoamDao, which had gotten huge
  */
-trait CommonOps extends Loggable {
+trait CommonDaoOps extends DbHelpers with Loggable {
   def descriptor: DbDescriptor
   
-  val driver: JdbcProfile
-
   import driver.api._
-  import driver.backend.DatabaseDef
-  import Futures.waitFor
   
   type WriteAction[A] =  driver.ProfileAction[A, NoStream, Effect.Write]
   
-  protected[slick] val db: DatabaseDef
+  protected[slick] val db: Database
 
   protected[slick] val tables: Tables
+
+  protected[slick] def runBlocking[A](action: DBIO[A]): A = runBlocking(db)(action)
   
   protected def log(sqlAction: driver.ProfileAction[_, _, _]): Unit = {
     sqlAction.statements.foreach(s => trace(s"SQL: $s"))
@@ -34,7 +35,4 @@ trait CommonOps extends Loggable {
     //TODO: re-evaluate; does this make sense?
     implicit val dbExecutionContext: ExecutionContext = db.executor.executionContext
   }
-  
-  //TODO: Re-evaluate; block all the time?
-  private[slick] def runBlocking[A](action: DBIO[A]): A = waitFor(db.run(action))
 }

--- a/src/main/scala/loamstream/db/slick/DbHelpers.scala
+++ b/src/main/scala/loamstream/db/slick/DbHelpers.scala
@@ -1,0 +1,21 @@
+package loamstream.db.slick
+
+import slick.jdbc.JdbcProfile
+import scala.concurrent.Future
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
+/**
+ * @author clint
+ * Jan 11, 2018
+ */
+trait DbHelpers {
+  val driver: JdbcProfile
+  
+  import driver.api._
+  
+  //TODO: Re-evaluate; block all the time?
+  private[slick] def runBlocking[A](db: Database)(action: DBIO[A]): A = blockOn(db.run(action))
+  
+  private[slick] def blockOn[A](future: Future[A]): A = Await.result(future, Duration.Inf)
+}

--- a/src/main/scala/loamstream/db/slick/ExecutionDaoOps.scala
+++ b/src/main/scala/loamstream/db/slick/ExecutionDaoOps.scala
@@ -18,7 +18,7 @@ import loamstream.model.execute.Settings
  * 
  * NB: Factored out of SlickLoamDao, which had gotten huge
  */
-trait ExecutionOps extends LoamDao { self: CommonOps with OutputOps =>
+trait ExecutionDaoOps extends LoamDao { self: CommonDaoOps with OutputDaoOps =>
   def descriptor: DbDescriptor
   
   val driver: JdbcProfile

--- a/src/main/scala/loamstream/db/slick/OutputDaoOps.scala
+++ b/src/main/scala/loamstream/db/slick/OutputDaoOps.scala
@@ -12,7 +12,7 @@ import loamstream.util.PathUtils
  * 
  * NB: Factored out of SlickLoamDao, which had gotten huge
  */
-trait OutputOps extends LoamDao { self: CommonOps =>
+trait OutputDaoOps extends LoamDao { self: CommonDaoOps =>
   def descriptor: DbDescriptor
   
   val driver: JdbcProfile

--- a/src/main/scala/loamstream/db/slick/SlickLoamDao.scala
+++ b/src/main/scala/loamstream/db/slick/SlickLoamDao.scala
@@ -25,12 +25,11 @@ import loamstream.util.PathUtils
  * For a schema description, see Tables
  */
 final class SlickLoamDao(val descriptor: DbDescriptor) extends 
-    LoamDao with CommonOps with OutputOps with ExecutionOps {
+    LoamDao with CommonDaoOps with OutputDaoOps with ExecutionDaoOps {
   
   override val driver = descriptor.dbType.driver
 
   import driver.api._
-  import loamstream.util.Futures.waitFor
 
   protected[slick] override lazy val db: driver.backend.DatabaseDef = {
     Database.forURL(url = descriptor.url, driver = descriptor.dbType.jdbcDriverClass)
@@ -50,5 +49,5 @@ final class SlickLoamDao(val descriptor: DbDescriptor) extends
 
   override def dropTables(): Unit = tables.drop(db)
 
-  override def shutdown(): Unit = waitFor(db.shutdown)
+  override def shutdown(): Unit = blockOn(db.shutdown)
 }

--- a/src/main/scala/loamstream/googlecloud/GoogleCloudChunkRunner.scala
+++ b/src/main/scala/loamstream/googlecloud/GoogleCloudChunkRunner.scala
@@ -3,7 +3,9 @@ package loamstream.googlecloud
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
+import scala.concurrent.Await
 import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.Duration
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
@@ -16,7 +18,6 @@ import loamstream.model.execute.Resources.LocalResources
 import loamstream.model.jobs.LJob
 import loamstream.model.jobs.RunData
 import loamstream.util.ExecutorServices
-import loamstream.util.Futures
 import loamstream.util.Loggable
 import loamstream.util.Maps
 import loamstream.util.Observables
@@ -98,7 +99,8 @@ final case class GoogleCloudChunkRunner(
 
     val futureResult = delegate.run(Set(job), shouldRestart).map(addCluster(googleConfig.clusterId)).firstAsFuture
     
-    Futures.waitFor(futureResult)
+    //TODO: add some timeout
+    Await.result(futureResult, Duration.Inf)
   }
   
   private[googlecloud] def withCluster[A](client: DataProcClient)(f: => A): A = {

--- a/src/main/scala/loamstream/util/Futures.scala
+++ b/src/main/scala/loamstream/util/Futures.scala
@@ -14,11 +14,6 @@ import scala.concurrent.duration.Duration
  */
 object Futures {
   /**
-   * Wait forever for a Future to complete, and return the result of the Future.
-   */
-  def waitFor[A](f: Future[A]): A = Await.result(f, Duration.Inf)
-  
-  /**
    * Runs a block of code in a Future, marking the code chunk as blocking.
    * 
    * @param a the block of code to run

--- a/src/test/scala/loamstream/TestHelpers.scala
+++ b/src/test/scala/loamstream/TestHelpers.scala
@@ -37,6 +37,8 @@ import org.apache.commons.io.FileUtils
 import loamstream.model.jobs.OutputStreams
 import java.util.UUID
 import loamstream.model.jobs.RunData
+import scala.concurrent.Future
+import scala.concurrent.Await
 
 /**
   * @author clint
@@ -162,4 +164,11 @@ object TestHelpers {
   def dummyFileName: Path = TestHelpers.path(s"${UUID.randomUUID.toString}.log")
     
   def dummyOutputStreams: OutputStreams = OutputStreams(dummyFileName, dummyFileName)
+  
+  def waitFor[A](f: Future[A]): A = {
+    import scala.concurrent.duration._
+
+    //NB: Hard-coded timeout. :(  But at least it's no longer infinite! :)
+    Await.result(f, 10.minutes)
+  }
 }

--- a/src/test/scala/loamstream/googlecloud/GoogleCloudChunkRunnerTest.scala
+++ b/src/test/scala/loamstream/googlecloud/GoogleCloudChunkRunnerTest.scala
@@ -28,12 +28,11 @@ import loamstream.model.jobs.RunData
  * Dec 15, 2016
  */
 final class GoogleCloudChunkRunnerTest extends FunSuite with ProvidesEnvAndResources {
-  //scalastyle:off magic.number
   
   import GoogleCloudChunkRunnerTest.LiteralMockDataProcClient
   import GoogleCloudChunkRunnerTest.MockDataProcClient
-  import loamstream.util.Futures.waitFor
   import loamstream.util.ObservableEnrichments._
+  import loamstream.TestHelpers.waitFor
 
   private val clusterId = "some-cluster-id"
   
@@ -545,6 +544,4 @@ object GoogleCloudChunkRunnerTest {
       clusterRunning := true
     }
   }
-  
-  //scalastyle:on magic.number
 }

--- a/src/test/scala/loamstream/model/execute/AsyncLocalChunkRunnerTest.scala
+++ b/src/test/scala/loamstream/model/execute/AsyncLocalChunkRunnerTest.scala
@@ -20,6 +20,7 @@ import loamstream.model.jobs.RunData
 final class AsyncLocalChunkRunnerTest extends FunSuite with TestJobs {
   import loamstream.TestHelpers.alwaysRestart
   import loamstream.TestHelpers.neverRestart
+  import loamstream.TestHelpers.waitFor
   
   test("handleResultOfExecution") {
     import JobStatus._
@@ -97,11 +98,11 @@ final class AsyncLocalChunkRunnerTest extends FunSuite with TestJobs {
     
     val failedJob = MockJob(Failed)
     
-    val success = Futures.waitFor(executeSingle(ExecutionConfig.default, job, neverRestart))
+    val success = waitFor(executeSingle(ExecutionConfig.default, job, neverRestart))
     
     assert(success === runDataFromStatus(job, Succeeded))
     
-    val failure = Futures.waitFor(executeSingle(ExecutionConfig.default, failedJob, neverRestart))
+    val failure = waitFor(executeSingle(ExecutionConfig.default, failedJob, neverRestart))
     
     assert(failure === runDataFromStatus(failedJob, Failed))
     
@@ -109,13 +110,12 @@ final class AsyncLocalChunkRunnerTest extends FunSuite with TestJobs {
     
     val two0StatusesFuture = job.statuses.take(3).to[Seq].firstAsFuture
     
-    assert(Futures.waitFor(two0StatusesFuture) === Seq(Running, Succeeded))
+    assert(waitFor(two0StatusesFuture) === Seq(Running, Succeeded))
   }
   
   test("executeSingle() - job transitioned to right state") {
     import AsyncLocalChunkRunner.executeSingle
     import JobStatus._
-    import Futures.waitFor
     import scala.concurrent.ExecutionContext.Implicits.global
     
     def doTest(status: JobStatus, expectedNoRestart: JobStatus): Unit = {

--- a/src/test/scala/loamstream/model/execute/CompositeChunkRunnerTest.scala
+++ b/src/test/scala/loamstream/model/execute/CompositeChunkRunnerTest.scala
@@ -9,7 +9,6 @@ import loamstream.model.jobs.JobStatus
 import loamstream.model.jobs.LJob
 import loamstream.model.jobs.MockJob
 import loamstream.model.jobs.RunData
-import loamstream.util.Futures
 import rx.lang.scala.Observable
 import loamstream.util.ObservableEnrichments
 
@@ -19,10 +18,9 @@ import loamstream.util.ObservableEnrichments
  */
 final class CompositeChunkRunnerTest extends FunSuite {
   
-  //scalastyle:off magic.number
-  
   import CompositeChunkRunnerTest.{ MockRunner, local }
   import loamstream.TestHelpers.neverRestart
+  import loamstream.TestHelpers.waitFor
   
   test("maxNumJobs") {
     val n1 = 3
@@ -76,10 +74,8 @@ final class CompositeChunkRunnerTest extends FunSuite {
     
     val expected = Map(job1 -> JobStatus.Succeeded, job2 -> JobStatus.Failed)
     
-    assert(Futures.waitFor(futureResults).mapValues(_.jobStatus) === expected)
+    assert(waitFor(futureResults).mapValues(_.jobStatus) === expected)
   }
-  
-  //scalastyle:on magic.number
 }
 
 object CompositeChunkRunnerTest {

--- a/src/test/scala/loamstream/model/execute/ExecutableTest.scala
+++ b/src/test/scala/loamstream/model/execute/ExecutableTest.scala
@@ -28,8 +28,8 @@ final class ExecutableTest extends FunSuite {
     
     val namesObservable = executable.multiplex(names(3))
     
-    import Futures.waitFor
     import ObservableEnrichments._
+    import loamstream.TestHelpers.waitFor
     
     val actualNames: Seq[String] = waitFor(namesObservable.to[Seq].firstAsFuture).sorted
     

--- a/src/test/scala/loamstream/model/jobs/JobTest.scala
+++ b/src/test/scala/loamstream/model/jobs/JobTest.scala
@@ -1,16 +1,13 @@
 package loamstream.model.jobs
 
-import org.scalatest.FunSuite
-import loamstream.util.Futures
-import loamstream.util.ObservableEnrichments
-
 import scala.concurrent.ExecutionContext
-import loamstream.util.Maps
-import loamstream.model.execute.AsyncLocalChunkRunner
-import loamstream.conf.ExecutionConfig
-import loamstream.TestHelpers
 import scala.concurrent.Future
-import rx.lang.scala.Observable
+
+import org.scalatest.FunSuite
+
+import loamstream.TestHelpers
+import loamstream.conf.ExecutionConfig
+import loamstream.model.execute.AsyncLocalChunkRunner
 
 /**
  * @author clint
@@ -19,8 +16,8 @@ import rx.lang.scala.Observable
 final class JobTest extends FunSuite with TestJobs {
   
   import JobStatus._
-  import Futures.waitFor
-  import ObservableEnrichments._
+  import loamstream.TestHelpers.waitFor
+  import loamstream.util.ObservableEnrichments._
 
   private def count[A](as: Seq[A]): Map[A, Int] = as.groupBy(identity).mapValues(_.size)
   

--- a/src/test/scala/loamstream/model/jobs/RxMockJob.scala
+++ b/src/test/scala/loamstream/model/jobs/RxMockJob.scala
@@ -43,7 +43,7 @@ final case class RxMockJob(
       
       val finalDepState = jobToWaitFor.lastStatus
       
-      Futures.waitFor(finalDepState.firstAsFuture)
+      loamstream.TestHelpers.waitFor(finalDepState.firstAsFuture)
     }
   }
 

--- a/src/test/scala/loamstream/uger/UgerChunkRunnerTest.scala
+++ b/src/test/scala/loamstream/uger/UgerChunkRunnerTest.scala
@@ -64,7 +64,7 @@ final class UgerChunkRunnerTest extends FunSuite {
   
   private val executionConfig: ExecutionConfig = ExecutionConfig(42, tempDir.resolve("bar")) 
   
-  import loamstream.util.Futures.waitFor
+  import loamstream.TestHelpers.waitFor
   import loamstream.util.ObservableEnrichments._
   
   test("NoOpJob is not attempted to be executed") {

--- a/src/test/scala/loamstream/util/FileWatchersTest.scala
+++ b/src/test/scala/loamstream/util/FileWatchersTest.scala
@@ -13,6 +13,7 @@ import better.files.{ File => BetterFile }
 final class FileWatchersTest extends FunSuite {
   
   import PathEnrichments._
+  import TestHelpers.waitFor
   
   test("Waiting for a file that eventually appears works") {
     val workDir = TestHelpers.getWorkDir(getClass.getSimpleName)
@@ -37,7 +38,7 @@ final class FileWatchersTest extends FunSuite {
       BetterFile(initiallyNonExistantFile).createIfNotExists()
     }
     
-    Futures.waitFor(future)
+    waitFor(future)
     
     assert(JFiles.exists(initiallyNonExistantFile))
   }
@@ -70,7 +71,7 @@ final class FileWatchersTest extends FunSuite {
     assert(JFiles.exists(initiallyNonExistantFile) === false)
     
     intercept[Exception] {
-      Futures.waitFor(future)
+      waitFor(future)
     }
     
     assert(JFiles.exists(initiallyNonExistantFile) === false)
@@ -91,7 +92,7 @@ final class FileWatchersTest extends FunSuite {
       end = System.currentTimeMillis
     }
     
-    Futures.waitFor(future)
+    waitFor(future)
     
     val elapsed = end - start
     
@@ -116,7 +117,7 @@ final class FileWatchersTest extends FunSuite {
     terminable.stop()
     
     intercept[Exception] {
-      Futures.waitFor(future)
+      waitFor(future)
     }
     
     val elapsed = end - start

--- a/src/test/scala/loamstream/util/FuturesTest.scala
+++ b/src/test/scala/loamstream/util/FuturesTest.scala
@@ -10,10 +10,11 @@ import scala.concurrent.duration.Duration
  * date: Jul 1, 2016
  */
 final class FuturesTest extends FunSuite {
-  import Futures.waitFor
+  
+  import loamstream.TestHelpers.waitFor
   import scala.concurrent.ExecutionContext.Implicits.global
   
-  test("toMap / waitFor") {
+  test("toMap") {
     import Futures.toMap
     
     val empty: Iterable[(Int, Future[String])] = Nil
@@ -25,12 +26,10 @@ final class FuturesTest extends FunSuite {
     assert(waitFor(toMap(tuples)) == Map(42 -> "x", 99 -> "y"))
   }
   
-  test("runBlocking / waitFor") {
+  test("runBlocking") {
     import scala.concurrent.ExecutionContext.Implicits.global
     
-    // scalastyle:off magic.number
     val f = Futures.runBlocking(42)
-    // scalastyle:on magic.number
     
     //We can't easily tell that the code chunk was marked 'blocking', so just see that the right
     //result comes back.

--- a/src/test/scala/loamstream/util/ObservablesTest.scala
+++ b/src/test/scala/loamstream/util/ObservablesTest.scala
@@ -11,11 +11,10 @@ import rx.lang.scala.Observable
  * date: Aug 26, 2016
  */
 final class ObservablesTest extends FunSuite {
-  import Futures.waitFor
+  
+  import loamstream.TestHelpers.waitFor
   import ObservableEnrichments._
   import Observables.sequence
-  
-  // scalastyle:off magic.number
   
   private def makeObservable[A](period: Int, msgs: A*): Observable[A] = {
     if(period == 0) {
@@ -233,6 +232,4 @@ final class ObservablesTest extends FunSuite {
     
     assert(strs.sorted === expected)
   }
-  
-  // scalastyle:on magic.number
 }


### PR DESCRIPTION
- Remove `Futures.waitFor`
- Attempt to consolidate and annotate blocking ops in non-test code.