### PR TITLE
Fix/long uger filenames

### DIFF
--- a/src/test/scala/loamstream/uger/ScriptBuilderTest.scala
+++ b/src/test/scala/loamstream/uger/ScriptBuilderTest.scala
@@ -96,7 +96,7 @@ final class ScriptBuilderTest extends FunSuite {
     val (discriminator0, discriminator1, discriminator2) = discriminators
     val (jobId0, jobId1, jobId2) = jobIds
 
-    val jobName = s"LoamStream-${jobId0}_${jobId1}_${jobId2}"
+    val jobName = s"LoamStream-${UgerTaskArray.hashJobIds(Seq(jobId0.toInt, jobId1.toInt, jobId2.toInt))}"
 
     val ugerDir = path("/humgen/diabetes/users/kyuksel/imputation/shapeit_example").toAbsolutePath.render
     val outputDir = path("out/job-outputs").toAbsolutePath.render

--- a/src/test/scala/loamstream/uger/UgerTaskArrayTest.scala
+++ b/src/test/scala/loamstream/uger/UgerTaskArrayTest.scala
@@ -40,9 +40,13 @@ final class UgerTaskArrayTest extends FunSuite {
 
     val jobName = UgerTaskArray.makeJobName(jobs)
 
-    val expected = s"LoamStream-${id0}_${id1}_${id2}"
+    // extract just the SHA from the job name
+    val sha = jobName.drop("LoamStream-".length)
+    val jobIds = UgerTaskArray.jobIdsOfSha(sha)
 
-    assert(jobName === expected)
+    val expected = Some(Seq(id0, id1, id2))
+
+    assert(jobIds === expected)
   }
 
   test("ugerStdOutPathTemplate") {


### PR DESCRIPTION
This is to fix a bug @rmkoesterer ran into where the job names on Uger were too long and failing. I kept the original code, but the final job name is a hash (SHA1) of the job IDs.

There is now a `Map(String, Seq[Int])` in `UgerTaskArray` that can be used by tests to lookup the job IDs from the SHA, and I figured @ClintAtTheBroad might want to write that map to disk (a TXT file?) for @rmkoesterer to use in case a job fails; should be able to look-up the SHA via a simple grep and see which jobs it corresponds to.