### PR TITLE
Cg fix too long uger jobnames

### DIFF
--- a/src/test/scala/loamstream/uger/ScriptBuilderTest.scala
+++ b/src/test/scala/loamstream/uger/ScriptBuilderTest.scala
@@ -27,13 +27,14 @@ final class ScriptBuilderTest extends FunSuite {
     val ugerConfig = TestHelpers.config.ugerConfig.get
 
     val jobs = Seq(getShapeItCommandLineJob(0), getShapeItCommandLineJob(1), getShapeItCommandLineJob(2))
-    val taskArray = UgerTaskArray.fromCommandLineJobs(ExecutionConfig.default, ugerConfig, jobs)
+    val jobName = UgerTaskArray.makeJobName()
+    val taskArray = UgerTaskArray.fromCommandLineJobs(ExecutionConfig.default, ugerConfig, jobs, jobName)
     val ugerScriptContents = ScriptBuilder.buildFrom(taskArray).withNormalizedLineBreaks
 
     val jobIds: (String, String, String) = (jobs(0).id.toString, jobs(1).id.toString, jobs(2).id.toString)
     val discriminators = (0, 1, 2)
-
-    val expectedScriptContents = expectedScriptAsString(discriminators, jobIds).withNormalizedLineBreaks
+    
+    val expectedScriptContents = expectedScriptAsString(jobName, discriminators, jobIds).withNormalizedLineBreaks
 
     assert(ugerScriptContents == expectedScriptContents)
   }
@@ -92,11 +93,13 @@ final class ScriptBuilderTest extends FunSuite {
   }
 
   // scalastyle:off method.length
-  private def expectedScriptAsString(discriminators: (Int, Int, Int), jobIds: (String, String, String)): String = {
+  private def expectedScriptAsString(
+      jobName: String, 
+      discriminators: (Int, Int, Int), 
+      jobIds: (String, String, String)): String = {
+    
     val (discriminator0, discriminator1, discriminator2) = discriminators
     val (jobId0, jobId1, jobId2) = jobIds
-
-    val jobName = s"LoamStream-${UgerTaskArray.hashJobIds(Seq(jobId0.toInt, jobId1.toInt, jobId2.toInt))}"
 
     val ugerDir = path("/humgen/diabetes/users/kyuksel/imputation/shapeit_example").toAbsolutePath.render
     val outputDir = path("out/job-outputs").toAbsolutePath.render

--- a/src/test/scala/loamstream/uger/UgerJobWrapperTest.scala
+++ b/src/test/scala/loamstream/uger/UgerJobWrapperTest.scala
@@ -18,11 +18,11 @@ final class UgerJobWrapperTest extends FunSuite {
   }
 
   test("ugerStdOutPath") {
-    val taskArray = UgerTaskArray.fromCommandLineJobs(executionConfig, ugerConfig, jobs)
+    val jobName = UgerTaskArray.makeJobName()
+    
+    val taskArray = UgerTaskArray.fromCommandLineJobs(executionConfig, ugerConfig, jobs, jobName)
 
     val Seq(wrapper0, wrapper1, wrapper2) = taskArray.ugerJobs
-
-    val jobName = UgerTaskArray.makeJobName(jobs)
 
     val ugerStdOutPath0 = wrapper0.ugerStdOutPath(taskArray)
     val ugerStdOutPath1 = wrapper1.ugerStdOutPath(taskArray)
@@ -38,11 +38,11 @@ final class UgerJobWrapperTest extends FunSuite {
   }
 
   test("ugerStdErrPath") {
-    val taskArray = UgerTaskArray.fromCommandLineJobs(executionConfig, ugerConfig, jobs)
+    val jobName = UgerTaskArray.makeJobName()
+    
+    val taskArray = UgerTaskArray.fromCommandLineJobs(executionConfig, ugerConfig, jobs, jobName)
 
     val Seq(wrapper0, wrapper1, wrapper2) = taskArray.ugerJobs
-
-    val jobName = UgerTaskArray.makeJobName(jobs)
 
     val ugerStdErrPath0 = wrapper0.ugerStdErrPath(taskArray)
     val ugerStdErrPath1 = wrapper1.ugerStdErrPath(taskArray)
@@ -59,8 +59,6 @@ final class UgerJobWrapperTest extends FunSuite {
 
   test("outputStreams.stdout") {
     val taskArray = UgerTaskArray.fromCommandLineJobs(executionConfig, ugerConfig, Seq(j0))
-
-    val jobName = UgerTaskArray.makeJobName(Seq(j0))
 
     val Seq(wrapper0) = taskArray.ugerJobs
 
@@ -80,11 +78,11 @@ final class UgerJobWrapperTest extends FunSuite {
   }
 
   test("ugerCommandLine") {
-    val taskArray = UgerTaskArray.fromCommandLineJobs(executionConfig, ugerConfig, Seq(j0))
+    val jobName = UgerTaskArray.makeJobName()
+    
+    val taskArray = UgerTaskArray.fromCommandLineJobs(executionConfig, ugerConfig, Seq(j0), jobName)
 
     val Seq(wrapper0) = taskArray.ugerJobs
-
-    val jobName = UgerTaskArray.makeJobName(Seq(j0))
 
     // scalastyle:off line.size.limit
     val expected = s"""|${j0.commandLineString}

--- a/src/test/scala/loamstream/uger/UgerTaskArrayTest.scala
+++ b/src/test/scala/loamstream/uger/UgerTaskArrayTest.scala
@@ -36,17 +36,10 @@ final class UgerTaskArrayTest extends FunSuite {
 
   test("makeJobName") {
 
-    val Seq(id0, id1, id2) = Seq(j0.id, j1.id, j2.id)
+    val jobName = UgerTaskArray.makeJobName()
 
-    val jobName = UgerTaskArray.makeJobName(jobs)
-
-    // extract just the SHA from the job name
-    val sha = jobName.drop("LoamStream-".length)
-    val jobIds = UgerTaskArray.jobIdsOfSha(sha)
-
-    val expected = Some(Seq(id0, id1, id2))
-
-    assert(jobIds === expected)
+    assert(jobName.startsWith("LoamStream-"))
+    assert(jobName.size === 47)
   }
 
   test("ugerStdOutPathTemplate") {
@@ -70,11 +63,11 @@ final class UgerTaskArrayTest extends FunSuite {
   }
 
   test("fromCommandLineJobs") {
-    val taskArray = UgerTaskArray.fromCommandLineJobs(executionConfig, ugerConfig, jobs)
+    val expectedJobName = UgerTaskArray.makeJobName()
+    
+    val taskArray = UgerTaskArray.fromCommandLineJobs(executionConfig, ugerConfig, jobs, expectedJobName)
 
     assert(taskArray.ugerConfig === ugerConfig)
-
-    val expectedJobName = UgerTaskArray.makeJobName(jobs)
 
     assert(taskArray.ugerJobName === expectedJobName)
 


### PR DESCRIPTION
This is based off of #288 , and solves the same problem, that too-long job names were being used for Uger jobs, leading to job failures.  

This PR generates job ids for Uger (just a UUID) and doesn't track the correspondence between Uger job names and LS job ids in any data structure, because that information is already logged in `Drmaa1Client.runJob`.