### PR TITLE
Feature request from Ryan: deprecate Tool.named in favor of Tool.tag

### DIFF
--- a/src/main/scala/loamstream/loam/LoamGraph.scala
+++ b/src/main/scala/loamstream/loam/LoamGraph.scala
@@ -249,17 +249,17 @@ final case class LoamGraph(
 
   def nameOf(t: Tool): Option[String] = namedTools.collectFirst { case (n, namedTool) if namedTool == t => n }
   
-  def withToolName(tool: Tool, name: String): LoamGraph = {
+  def withToolName(tool: Tool, tagName: String): LoamGraph = {
     //TODO: Throw here, or elsewhere?  Make this a loam-compilation-time error another way?
-    if(namedTools.contains(name)) {
-      throw new Exception(s"Tool name '$name' must be unique.")
+    if(namedTools.contains(tagName)) {
+      throw new Exception(s"Tool tag name '$tagName' must be unique.")
     }
     
     if(namedTools.values.toSet.contains(tool)) {
-      throw new Exception(s"Tool '$tool' is already named ${nameOf(tool).get}")
+      throw new Exception(s"Tool '$tool' is already tagged as ${nameOf(tool).get}")
     }
     
-    copy(namedTools = namedTools + (name -> tool))
+    copy(namedTools = namedTools + (tagName -> tool))
   }
   
   def without(toolsToExclude: Set[Tool]): LoamGraph = containingOnly(tools -- toolsToExclude)

--- a/src/main/scala/loamstream/model/Tool.scala
+++ b/src/main/scala/loamstream/model/Tool.scala
@@ -12,9 +12,6 @@ import loamstream.model.Tool.DefaultStores
   */
 trait Tool extends LId.HasId {
 
-  /** The unique tool id */
-  def id: LId
-
   /** The LoamProjectContext associated with this tool */
   def projectContext: LoamProjectContext = scriptContext.projectContext
 
@@ -59,7 +56,10 @@ trait Tool extends LId.HasId {
 
   def workDirOpt: Option[Path] = graph.workDirs.get(this)
   
-  def named(name: String): this.type = {
+  @deprecated(message = "Use tag(name) instead", since = "")
+  def named(name: String): this.type = tag(name)
+  
+  def tag(name: String): this.type = {
     projectContext.updateGraph(_.withToolName(this, name))
     
     this

--- a/src/test/scala/loamstream/model/ToolTest.scala
+++ b/src/test/scala/loamstream/model/ToolTest.scala
@@ -13,50 +13,55 @@ import loamstream.loam.LoamCmdTool
 final class ToolTest extends FunSuite {
   //TODO: More!!!
   
-  test("named") {
-    implicit val scriptContext: LoamScriptContext = new LoamScriptContext(TestHelpers.emptyProjectContext)
-    
-    import LoamPredef._
-    import LoamCmdTool._
-    
-    def graph = scriptContext.projectContext.graph
-    
-    assert(graph.tools === Set.empty)
-    assert(graph.namedTools === Map.empty)
-    
-    val tool0 = cmd"foo --bar --baz"
-    val tool1 = cmd"bar --baz"
-    
-    assert(graph.tools === Set(tool0, tool1))
-    assert(graph.namedTools === Map.empty)
-    
-    val namedTool0 = tool0.named("foo")
-    
-    assert(namedTool0 eq tool0)
-    
-    assert(graph.tools === Set(tool0, tool1))
-    assert(graph.namedTools === Map("foo" -> tool0))
-    
-    val namedTool1 = tool1.named("bar")
-    
-    assert(namedTool1 eq tool1)
-    
-    assert(graph.tools === Set(tool0, tool1))
-    assert(graph.namedTools === Map("foo" -> tool0, "bar" -> tool1))
-    
-    val tool2 = cmd"baz"
-    
-    assert(graph.tools === Set(tool0, tool1, tool2))
-    assert(graph.namedTools === Map("foo" -> tool0, "bar" -> tool1))
-    
-    //non-unique name
-    intercept[Exception] {
-      tool2.named("foo")
+  test("named/tag") {
+    def doTest(method: Tool => String => Tool): Unit = {
+      implicit val scriptContext: LoamScriptContext = new LoamScriptContext(TestHelpers.emptyProjectContext)
+      
+      import LoamPredef._
+      import LoamCmdTool._
+      
+      def graph = scriptContext.projectContext.graph
+      
+      assert(graph.tools === Set.empty)
+      assert(graph.namedTools === Map.empty)
+      
+      val tool0 = cmd"foo --bar --baz"
+      val tool1 = cmd"bar --baz"
+      
+      assert(graph.tools === Set(tool0, tool1))
+      assert(graph.namedTools === Map.empty)
+      
+      val namedTool0 = method(tool0)("foo")
+      
+      assert(namedTool0 eq tool0)
+      
+      assert(graph.tools === Set(tool0, tool1))
+      assert(graph.namedTools === Map("foo" -> tool0))
+      
+      val namedTool1 = method(tool1)("bar")
+      
+      assert(namedTool1 eq tool1)
+      
+      assert(graph.tools === Set(tool0, tool1))
+      assert(graph.namedTools === Map("foo" -> tool0, "bar" -> tool1))
+      
+      val tool2 = cmd"baz"
+      
+      assert(graph.tools === Set(tool0, tool1, tool2))
+      assert(graph.namedTools === Map("foo" -> tool0, "bar" -> tool1))
+      
+      //non-unique name
+      intercept[Exception] {
+        method(tool2)("foo")
+      }
+      
+      //re-naming
+      intercept[Exception] {
+        method(tool0)("sadf")
+      }
     }
     
-    //re-naming
-    intercept[Exception] {
-      tool0.named("sadf")
-    }
+    doTest(_.named)
+    doTest(_.tag)
   }
 }


### PR DESCRIPTION
As expected for so minor a change, the integration tests passed.