### PR TITLE
CLI fixes: make sure --uger and --lsf aren't ignored

### DIFF
--- a/src/main/scala/loamstream/cli/Intent.scala
+++ b/src/main/scala/loamstream/cli/Intent.scala
@@ -26,7 +26,10 @@ object Intent extends Loggable {
 
   final case class LookupOutput(confFile: Option[Path], output: Either[Path, URI]) extends Intent
 
-  final case class CompileOnly(confFile: Option[Path], loams: Seq[Path]) extends Intent
+  final case class CompileOnly(
+      confFile: Option[Path], 
+      drmSystemOpt: Option[DrmSystem], 
+      loams: Seq[Path]) extends Intent
 
   final case class DryRun(
     confFile: Option[Path],
@@ -62,7 +65,7 @@ object Intent extends Loggable {
     else if (values.helpSupplied) { Right(ShowHelpAndQuit) }
     else if (confDoesntExist) { Left(s"Config file '${values.conf.get}' specified, but it doesn't exist.") }
     else if (values.lookupSupplied) { Right(LookupOutput(values.conf, values.lookup.get)) }
-    else if (compileOnly(values)) { Right(CompileOnly(values.conf, values.loams)) }
+    else if (compileOnly(values)) { Right(CompileOnly(values.conf, getDrmSystem(values), values.loams)) }
     else if (dryRun(values)) {
       Right(makeDryRun(values))
     } else if (allLoamsExist) {

--- a/src/test/scala/loamstream/cli/IntentTest.scala
+++ b/src/test/scala/loamstream/cli/IntentTest.scala
@@ -72,11 +72,13 @@ final class IntentTest extends FunSuite {
     //--compile-only
     assertInvalid("--compile-only") //no loams specified
     
-    assertValid(s"--compile-only $exampleFile0 $exampleFile1", CompileOnly(None, paths(exampleFile0, exampleFile1)))
+    assertIsValidWithAllDrmSystems(
+        s"--compile-only $exampleFile0 $exampleFile1", 
+        drmSysOpt => CompileOnly(None, drmSysOpt, paths(exampleFile0, exampleFile1)))
     
-    assertValid(
+    assertIsValidWithAllDrmSystems(
         s"--conf $confFile --compile-only $exampleFile0 $exampleFile1", 
-        CompileOnly(Some(confPath), paths(exampleFile0, exampleFile1)))
+        drmSysOpt => CompileOnly(Some(confPath), drmSysOpt, paths(exampleFile0, exampleFile1)))
     
     assertInvalid(s"--conf $confFile --compile-only $exampleFile0 $nonExistentFile") //nonexistent loam file
     


### PR DESCRIPTION
This fixes bugs where `--uger` and `--lsf` were ignored if `--dry-run` or `--compile-only` were specified.