### PR TITLE
Allow running jobs in containers on LSF via local images from the FS, not a repository.

### DIFF
--- a/src/main/scala/loamstream/drm/DrmJobWrapper.scala
+++ b/src/main/scala/loamstream/drm/DrmJobWrapper.scala
@@ -53,8 +53,8 @@ final case class DrmJobWrapper(
         |stderrDestPath="${stdErrDestPath.render}"
         |
         |mkdir -p ${outputDir.render}
-        |mv ${drmStdOutPath(taskArray).render} $$stdoutDestPath || echo "Couldn't move DRM std out log" > $$stdoutDestPath
-        |mv ${drmStdErrPath(taskArray).render} $$stderrDestPath || echo "Couldn't move DRM std err log" > $$stderrDestPath
+        |mv ${drmStdOutPath(taskArray).render} $$stdoutDestPath || echo "Couldn't move DRM std out log ${drmStdOutPath(taskArray).render}; it's likely the job wasn't submitted successfully" > $$stdoutDestPath
+        |mv ${drmStdErrPath(taskArray).render} $$stderrDestPath || echo "Couldn't move DRM std err log ${drmStdErrPath(taskArray).render}; it's likely the job wasn't submitted successfully" > $$stderrDestPath
         |
         |exit $$LOAMSTREAM_JOB_EXIT_CODE
         |""".stripMargin

--- a/src/main/scala/loamstream/model/execute/Settings.scala
+++ b/src/main/scala/loamstream/model/execute/Settings.scala
@@ -62,7 +62,7 @@ final case class LsfDrmSettings(
   
   override def commandLineInTaskArray(job: HasCommandLine): String = {
     val singularityPart = dockerParams match { 
-      case Some(params) => s"singularity exec docker://${params.imageName} "
+      case Some(params) => s"singularity exec ${params.imageName} "
       case _ => ""
     }
     

--- a/src/test/scala/loamstream/drm/DrmJobWrapperTest.scala
+++ b/src/test/scala/loamstream/drm/DrmJobWrapperTest.scala
@@ -113,7 +113,7 @@ final class DrmJobWrapperTest extends FunSuite {
     doTest(LsfPathBuilder)
   }
 
-  test("ugerCommandLine") {
+  test("commandChunk") {
     def doTest(pathBuilder: PathBuilder): Unit = {
       val jobName = DrmTaskArray.makeJobName()
       
@@ -132,8 +132,8 @@ final class DrmJobWrapperTest extends FunSuite {
                          |stderrDestPath="${jobOutputDir.render}/${j0.id}.stderr"
                          |
                          |mkdir -p ${jobOutputDir.render}
-                         |mv ${workDir.render}/$jobName.1.stdout $$stdoutDestPath || echo "Couldn't move DRM std out log" > $$stdoutDestPath
-                         |mv ${workDir.render}/$jobName.1.stderr $$stderrDestPath || echo "Couldn't move DRM std err log" > $$stderrDestPath
+                         |mv ${workDir.render}/$jobName.1.stdout $$stdoutDestPath || echo "Couldn't move DRM std out log ${workDir.render}/$jobName.1.stdout; it's likely the job wasn't submitted successfully" > $$stdoutDestPath
+                         |mv ${workDir.render}/$jobName.1.stderr $$stderrDestPath || echo "Couldn't move DRM std err log ${workDir.render}/$jobName.1.stderr; it's likely the job wasn't submitted successfully" > $$stderrDestPath
                          |
                          |exit $$LOAMSTREAM_JOB_EXIT_CODE
                          |""".stripMargin

--- a/src/test/scala/loamstream/drm/ScriptBuilderTest.scala
+++ b/src/test/scala/loamstream/drm/ScriptBuilderTest.scala
@@ -169,7 +169,7 @@ final class ScriptBuilderTest extends FunSuite {
     val sixSpaces = "      "
 
     val singularityPrefix: String = (drmSystem, dockerParamsOpt) match {
-      case (DrmSystem.Lsf, Some(dockerParams)) => s"singularity exec docker://${dockerParams.imageName} "
+      case (DrmSystem.Lsf, Some(dockerParams)) => s"singularity exec ${dockerParams.imageName} "
       case _ => ""
     }
     
@@ -206,8 +206,8 @@ stdoutDestPath="$finalOutputDir/${jobId0}.stdout"
 stderrDestPath="$finalOutputDir/${jobId0}.stderr"
 
 mkdir -p $finalOutputDir
-mv $drmOutputDir/${jobName}.1.stdout $$stdoutDestPath || echo "Couldn't move DRM std out log" > $$stdoutDestPath
-mv $drmOutputDir/${jobName}.1.stderr $$stderrDestPath || echo "Couldn't move DRM std err log" > $$stderrDestPath
+mv $drmOutputDir/${jobName}.1.stdout $$stdoutDestPath || echo "Couldn't move DRM std out log $drmOutputDir/${jobName}.1.stdout; it's likely the job wasn't submitted successfully" > $$stdoutDestPath
+mv $drmOutputDir/${jobName}.1.stderr $$stderrDestPath || echo "Couldn't move DRM std err log $drmOutputDir/${jobName}.1.stderr; it's likely the job wasn't submitted successfully" > $$stderrDestPath
 
 exit $$LOAMSTREAM_JOB_EXIT_CODE
 
@@ -221,8 +221,8 @@ stdoutDestPath="$finalOutputDir/${jobId1}.stdout"
 stderrDestPath="$finalOutputDir/${jobId1}.stderr"
 
 mkdir -p $finalOutputDir
-mv $drmOutputDir/${jobName}.2.stdout $$stdoutDestPath || echo "Couldn't move DRM std out log" > $$stdoutDestPath
-mv $drmOutputDir/${jobName}.2.stderr $$stderrDestPath || echo "Couldn't move DRM std err log" > $$stderrDestPath
+mv $drmOutputDir/${jobName}.2.stdout $$stdoutDestPath || echo "Couldn't move DRM std out log $drmOutputDir/${jobName}.2.stdout; it's likely the job wasn't submitted successfully" > $$stdoutDestPath
+mv $drmOutputDir/${jobName}.2.stderr $$stderrDestPath || echo "Couldn't move DRM std err log $drmOutputDir/${jobName}.2.stderr; it's likely the job wasn't submitted successfully" > $$stderrDestPath
 
 exit $$LOAMSTREAM_JOB_EXIT_CODE
 
@@ -236,8 +236,8 @@ stdoutDestPath="$finalOutputDir/${jobId2}.stdout"
 stderrDestPath="$finalOutputDir/${jobId2}.stderr"
 
 mkdir -p $finalOutputDir
-mv $drmOutputDir/${jobName}.3.stdout $$stdoutDestPath || echo "Couldn't move DRM std out log" > $$stdoutDestPath
-mv $drmOutputDir/${jobName}.3.stderr $$stderrDestPath || echo "Couldn't move DRM std err log" > $$stderrDestPath
+mv $drmOutputDir/${jobName}.3.stdout $$stdoutDestPath || echo "Couldn't move DRM std out log $drmOutputDir/${jobName}.3.stdout; it's likely the job wasn't submitted successfully" > $$stdoutDestPath
+mv $drmOutputDir/${jobName}.3.stderr $$stderrDestPath || echo "Couldn't move DRM std err log $drmOutputDir/${jobName}.3.stderr; it's likely the job wasn't submitted successfully" > $$stderrDestPath
 
 exit $$LOAMSTREAM_JOB_EXIT_CODE
 


### PR DESCRIPTION
- Don't add docker:// to image names when running in a container on LSF.
- Better error output when DRM stdout/stderr files can't be moved to their final locations.