### PR TITLE
Allow configuring Conda Env activated by Uger scripts

### DIFF
--- a/src/main/scala/loamstream/apps/AppWiring.scala
+++ b/src/main/scala/loamstream/apps/AppWiring.scala
@@ -78,6 +78,7 @@ import loamstream.model.execute.ExecutionRecorder
 import loamstream.model.execute.DbBackedExecutionRecorder
 import loamstream.cli.JobFilterIntent
 import loamstream.model.execute.ByNameJobFilter
+import loamstream.drm.uger.UgerScriptBuilderParams
 
 
 /**
@@ -381,7 +382,7 @@ object AppWiring extends Loggable {
         
         DrmChunkRunner(
             environmentType = EnvironmentType.Uger,
-            pathBuilder = UgerPathBuilder,
+            pathBuilder = new UgerPathBuilder(UgerScriptBuilderParams(ugerConfig)),
             executionConfig = loamConfig.executionConfig, 
             drmConfig = ugerConfig, 
             jobSubmitter = jobSubmitter, 

--- a/src/main/scala/loamstream/conf/DrmConfig.scala
+++ b/src/main/scala/loamstream/conf/DrmConfig.scala
@@ -36,13 +36,7 @@ sealed trait DrmConfig {
   
   final def isLsfConfig: Boolean = this.isInstanceOf[LsfConfig]
   
-  //TODO: This feels wrong
-  final def scriptBuilderParams: ScriptBuilderParams = {
-    require(isUgerConfig || isLsfConfig)
-    
-    if(isUgerConfig) { UgerScriptBuilderParams }
-    else { LsfScriptBuilderParams }
-  }
+  def scriptBuilderParams: ScriptBuilderParams
 }
 
 /**
@@ -55,7 +49,12 @@ final case class UgerConfig(
     maxNumJobs: Int = UgerDefaults.maxConcurrentJobs,
     defaultCores: Cpus = UgerDefaults.cores,
     defaultMemoryPerCore: Memory = UgerDefaults.memoryPerCore,
-    defaultMaxRunTime: CpuTime = UgerDefaults.maxRunTime) extends DrmConfig
+    defaultMaxRunTime: CpuTime = UgerDefaults.maxRunTime,
+    extraPathDir: Path = UgerDefaults.extraPathDir,
+    condaEnvName: String = UgerDefaults.condaEnvName) extends DrmConfig {
+  
+  override def scriptBuilderParams: ScriptBuilderParams = new UgerScriptBuilderParams(extraPathDir, condaEnvName)
+}
 
 object UgerConfig extends ConfigParser[UgerConfig] with Loggable {
 
@@ -87,7 +86,10 @@ final case class LsfConfig(
     maxNumJobs: Int = LsfDefaults.maxConcurrentJobs,
     defaultCores: Cpus = LsfDefaults.cores,
     defaultMemoryPerCore: Memory = LsfDefaults.memoryPerCore,
-    defaultMaxRunTime: CpuTime = LsfDefaults.maxRunTime) extends DrmConfig
+    defaultMaxRunTime: CpuTime = LsfDefaults.maxRunTime) extends DrmConfig {
+  
+  override def scriptBuilderParams: ScriptBuilderParams = LsfScriptBuilderParams
+}
 
 object LsfConfig extends ConfigParser[LsfConfig] with Loggable {
 

--- a/src/main/scala/loamstream/drm/uger/UgerDefaults.scala
+++ b/src/main/scala/loamstream/drm/uger/UgerDefaults.scala
@@ -4,6 +4,8 @@ import loamstream.drm.Queue
 import loamstream.model.quantities.CpuTime
 import loamstream.model.quantities.Cpus
 import loamstream.model.quantities.Memory
+import java.nio.file.Paths
+import java.nio.file.Path
 
 /**
  * @author clint
@@ -19,4 +21,8 @@ object UgerDefaults {
   val maxRunTime: CpuTime = CpuTime.inHours(2)
   
   val queue: Queue = Queue("broad")
+  
+  val extraPathDir: Path = Paths.get("/humgen/diabetes/users/dig/miniconda2/bin")
+
+  val condaEnvName: String = "loamstream_v1.0"
 }

--- a/src/main/scala/loamstream/drm/uger/UgerPathBuilder.scala
+++ b/src/main/scala/loamstream/drm/uger/UgerPathBuilder.scala
@@ -10,7 +10,7 @@ import loamstream.drm.ScriptBuilderParams
  * @author clint
  * May 11, 2018
  */
-object UgerPathBuilder extends PathBuilder {
+final class UgerPathBuilder(override val scriptBuilderParams: UgerScriptBuilderParams) extends PathBuilder {
   override def reifyPathTemplate(template: String, drmIndex: Int): Path = {
     //NB: Replace task-array-index placeholder, drop initial ':'
     val pathString = template.replace(scriptBuilderParams.drmIndexVarExpr, drmIndex.toString).dropWhile(_ == ':')
@@ -20,6 +20,4 @@ object UgerPathBuilder extends PathBuilder {
   
   //NB: Need to build this differently by environment (':' for Uger, '' for LSF)
   override def pathTemplatePrefix: String = ":"
-  
-  override def scriptBuilderParams: ScriptBuilderParams = UgerScriptBuilderParams
 }

--- a/src/main/scala/loamstream/drm/uger/UgerPathBuilder.scala
+++ b/src/main/scala/loamstream/drm/uger/UgerPathBuilder.scala
@@ -10,7 +10,7 @@ import loamstream.drm.ScriptBuilderParams
  * @author clint
  * May 11, 2018
  */
-final class UgerPathBuilder(override val scriptBuilderParams: UgerScriptBuilderParams) extends PathBuilder {
+final case class UgerPathBuilder(override val scriptBuilderParams: UgerScriptBuilderParams) extends PathBuilder {
   override def reifyPathTemplate(template: String, drmIndex: Int): Path = {
     //NB: Replace task-array-index placeholder, drop initial ':'
     val pathString = template.replace(scriptBuilderParams.drmIndexVarExpr, drmIndex.toString).dropWhile(_ == ':')

--- a/src/main/scala/loamstream/drm/uger/UgerScriptBuilderParams.scala
+++ b/src/main/scala/loamstream/drm/uger/UgerScriptBuilderParams.scala
@@ -9,7 +9,7 @@ import loamstream.conf.UgerConfig
  * @author clint
  * May 11, 2018
  */
-final class UgerScriptBuilderParams(extraPathDir: Path, condaEnvName: String) extends ScriptBuilderParams {
+final case class UgerScriptBuilderParams(extraPathDir: Path, condaEnvName: String) extends ScriptBuilderParams {
   
   /*
    * We need to 'use' Java-1.8 to make some steps of the QC pipeline work.

--- a/src/main/scala/loamstream/drm/uger/UgerScriptBuilderParams.scala
+++ b/src/main/scala/loamstream/drm/uger/UgerScriptBuilderParams.scala
@@ -2,12 +2,14 @@ package loamstream.drm.uger
 
 import org.ggf.drmaa.JobTemplate
 import loamstream.drm.ScriptBuilderParams
+import java.nio.file.Path
+import loamstream.conf.UgerConfig
 
 /**
  * @author clint
  * May 11, 2018
  */
-object UgerScriptBuilderParams extends ScriptBuilderParams {
+final class UgerScriptBuilderParams(extraPathDir: Path, condaEnvName: String) extends ScriptBuilderParams {
   
   /*
    * We need to 'use' Java-1.8 to make some steps of the QC pipeline work.
@@ -17,20 +19,26 @@ object UgerScriptBuilderParams extends ScriptBuilderParams {
    * from BITS at 
    * https://broad.service-now.com/nav_to.do?uri=%2Fkb_view.do%3Fsysparm_article%3DKB0010821 
    */
-  private def ugerPreamble = """|#$ -cwd
-                                |
-                                |source /broad/software/scripts/useuse
-                                |reuse -q UGER
-                                |reuse -q Java-1.8
-                                |
-                                |export PATH=/humgen/diabetes/users/dig/miniconda2/bin:$PATH
-                                |source activate loamstream_v1.0
-                                |
-                                |mkdir -p /broad/hptmp/${USER}
-                                |export SINGULARITY_CACHEDIR=/broad/hptmp/${USER}""".stripMargin
+  private def ugerPreamble = s"""|#$$ -cwd
+                                 |
+                                 |source /broad/software/scripts/useuse
+                                 |reuse -q UGER
+                                 |reuse -q Java-1.8
+                                 |
+                                 |export PATH=${extraPathDir}:$$PATH
+                                 |source activate ${condaEnvName}
+                                 |
+                                 |mkdir -p /broad/hptmp/$${USER}
+                                 |export SINGULARITY_CACHEDIR=/broad/hptmp/$${USER}""".stripMargin
   
   override val preamble: Option[String] = Option(ugerPreamble) 
   override val indexEnvVarName: String = "SGE_TASK_ID" 
   override val jobIdEnvVarName: String = "JOB_ID"
   override val drmIndexVarExpr: String = JobTemplate.PARAMETRIC_INDEX
+}
+
+object UgerScriptBuilderParams {
+  def apply(ugerConfig: UgerConfig): UgerScriptBuilderParams = {
+    new UgerScriptBuilderParams(ugerConfig.extraPathDir, ugerConfig.condaEnvName)
+  }
 }

--- a/src/main/scala/loamstream/model/execute/CompositeChunkRunner.scala
+++ b/src/main/scala/loamstream/model/execute/CompositeChunkRunner.scala
@@ -17,7 +17,6 @@ final case class CompositeChunkRunner(components: Seq[ChunkRunner]) extends Chun
   
   override def canRun(job: LJob): Boolean = components.exists(_.canRun(job))
   
-  //TODO
   override def run(jobs: Set[LJob], shouldRestart: LJob => Boolean): Observable[Map[LJob, RunData]] = {
     
     require(jobs.forall(canRun), s"Don't know how to run ${jobs.filterNot(canRun)}")

--- a/src/main/scala/loamstream/model/execute/Settings.scala
+++ b/src/main/scala/loamstream/model/execute/Settings.scala
@@ -22,7 +22,6 @@ import loamstream.model.jobs.commandline.HasCommandLine
  * @author clint
  *         date: 3/7/17
  */
-
 sealed trait Settings
 
 /**

--- a/src/test/scala/loamstream/apps/AppWiringTest.scala
+++ b/src/test/scala/loamstream/apps/AppWiringTest.scala
@@ -21,6 +21,7 @@ import loamstream.conf.LoamConfig
 import loamstream.drm.lsf.LsfPathBuilder
 import loamstream.drm.uger.UgerPathBuilder
 import loamstream.drm.PathBuilder
+import loamstream.drm.uger.UgerScriptBuilderParams
 
 
 /**
@@ -195,8 +196,11 @@ final class AppWiringTest extends FunSuite with Matchers {
       
       assert(drmRunner.pathBuilder === expectedPathBuilder)
     }
+
+    val loamConfig = LoamConfig.fromPath(confFileForUger).get
     
-    doTest(DrmSystem.Uger, UgerPathBuilder)
+    doTest(DrmSystem.Uger, new UgerPathBuilder(UgerScriptBuilderParams(loamConfig.ugerConfig.get)))
+    
     doTest(DrmSystem.Lsf, LsfPathBuilder)
   }
   

--- a/src/test/scala/loamstream/conf/UgerConfigTest.scala
+++ b/src/test/scala/loamstream/conf/UgerConfigTest.scala
@@ -8,12 +8,29 @@ import loamstream.model.quantities.Cpus
 import loamstream.model.quantities.Memory
 import loamstream.model.quantities.CpuTime
 import loamstream.drm.uger.UgerDefaults
+import loamstream.TestHelpers
 
 /**
  * @author clint
  * date: Jun 1, 2016
  */
 final class UgerConfigTest extends FunSuite {
+  import TestHelpers.path
+  
+  test("defaults") {
+    val fooBar = path("/foo/bar")
+    
+    val config = UgerConfig(workDir = fooBar)
+    
+    assert(config.workDir === fooBar)
+    assert(config.maxNumJobs === UgerDefaults.maxConcurrentJobs)
+    assert(config.defaultCores === UgerDefaults.cores)
+    assert(config.defaultMemoryPerCore === UgerDefaults.memoryPerCore)
+    assert(config.defaultMaxRunTime === UgerDefaults.maxRunTime)
+    assert(config.extraPathDir === UgerDefaults.extraPathDir)
+    assert(config.condaEnvName === UgerDefaults.condaEnvName)
+  }
+  
   test("Parsing bad input should fail") {
     assert(UgerConfig.fromConfig(ConfigFactory.empty()).isFailure)
     
@@ -22,7 +39,7 @@ final class UgerConfigTest extends FunSuite {
     assert(UgerConfig.fromConfig(ConfigFactory.parseString("{}")).isFailure)
   }
   
-  test("Parsing a UgerConfig should work") {
+  test("Parsing a UgerConfig with all values provided should work") {
     val valid = ConfigFactory.parseString("""
       loamstream {
         uger {
@@ -31,6 +48,8 @@ final class UgerConfigTest extends FunSuite {
           defaultCores = 42
           defaultMemoryPerCore = 9 // Gb
           defaultMaxRunTime = 11 // hours
+          extraPathDir = /blah/baz
+          condaEnvName = fooEnv
         }
       }
       """)
@@ -42,6 +61,8 @@ final class UgerConfigTest extends FunSuite {
     assert(ugerConfig.defaultCores === Cpus(42))
     assert(ugerConfig.defaultMemoryPerCore=== Memory.inGb(9))
     assert(ugerConfig.defaultMaxRunTime === CpuTime.inHours(11))
+    assert(ugerConfig.extraPathDir === path("/blah/baz"))
+    assert(ugerConfig.condaEnvName === "fooEnv")
   }
   
   test("Parsing a UgerConfig with optional values omitted should work") {
@@ -49,8 +70,6 @@ final class UgerConfigTest extends FunSuite {
       loamstream {
         uger {
           workDir = "/foo/bar/baz"
-          logFile = "nuh/zuh.log"
-          maxNumJobs=44
         }
       }
       """)
@@ -58,9 +77,11 @@ final class UgerConfigTest extends FunSuite {
     val ugerConfig = UgerConfig.fromConfig(valid).get
     
     assert(ugerConfig.workDir === Paths.get("/foo/bar/baz"))
-    assert(ugerConfig.maxNumJobs === 44)
+    assert(ugerConfig.maxNumJobs === UgerDefaults.maxConcurrentJobs)
     assert(ugerConfig.defaultCores === UgerDefaults.cores)
-    assert(ugerConfig.defaultMemoryPerCore=== UgerDefaults.memoryPerCore)
+    assert(ugerConfig.defaultMemoryPerCore === UgerDefaults.memoryPerCore)
     assert(ugerConfig.defaultMaxRunTime === UgerDefaults.maxRunTime)
+    assert(ugerConfig.extraPathDir === UgerDefaults.extraPathDir)
+    assert(ugerConfig.condaEnvName === UgerDefaults.condaEnvName)
   }
 }

--- a/src/test/scala/loamstream/drm/DrmChunkRunnerTest.scala
+++ b/src/test/scala/loamstream/drm/DrmChunkRunnerTest.scala
@@ -40,6 +40,7 @@ import loamstream.drm.DrmChunkRunnerTest.MockJobSubmitter
 import scala.util.Try
 import loamstream.loam.LoamGraph
 import loamstream.model.Tool
+import loamstream.drm.uger.UgerScriptBuilderParams
 
 
 /**
@@ -91,11 +92,13 @@ final class DrmChunkRunnerTest extends FunSuite {
     override def stop(): Unit = ()
   }
   
+  private val ugerPathBuilder = new UgerPathBuilder(UgerScriptBuilderParams(ugerConfig))
+  
   test("No failures when empty set of jobs is presented - Uger") {
     val mockDrmaaClient = new MockDrmaaClient(Map.empty)
     val runner = DrmChunkRunner(
         environmentType = EnvironmentType.Uger,
-        pathBuilder = UgerPathBuilder,
+        pathBuilder = ugerPathBuilder,
         executionConfig = executionConfig,
         drmConfig = ugerConfig,
         jobSubmitter = JobSubmitter.Drmaa(mockDrmaaClient, ugerConfig),
@@ -231,7 +234,7 @@ final class DrmChunkRunnerTest extends FunSuite {
     def doTest(shouldRestart: LJob => Boolean, lastUgerStatus: DrmStatus, expectedLastStatus: JobStatus): Unit = {
       val job = MockDrmJob(id, Queued, Queued, Running, Running, lastUgerStatus)
       
-      val failed = DrmJobWrapper(ExecutionConfig.default, defaultUgerSettings, UgerPathBuilder, job, 1)
+      val failed = DrmJobWrapper(ExecutionConfig.default, defaultUgerSettings, ugerPathBuilder, job, 1)
       
       assert(job.runCount === 0)
       
@@ -273,7 +276,7 @@ final class DrmChunkRunnerTest extends FunSuite {
     def doTest(shouldRestart: LJob => Boolean, lastUgerStatus: DrmStatus, expectedLastStatus: JobStatus): Unit = {
       val job = MockDrmJob(id, Queued, Queued, Running, Running, lastUgerStatus)
       
-      val worked = DrmJobWrapper(ExecutionConfig.default, defaultUgerSettings, UgerPathBuilder, job, 1)
+      val worked = DrmJobWrapper(ExecutionConfig.default, defaultUgerSettings, ugerPathBuilder, job, 1)
       
       assert(job.runCount === 0)
       
@@ -321,8 +324,8 @@ final class DrmChunkRunnerTest extends FunSuite {
       val workedJob = MockDrmJob(goodId, Queued, Queued, Running, Running, lastGoodDrmStatus)
       val failedJob = MockDrmJob(badId, Queued, Queued, Running, Running, lastBadDrmStatus)
       
-      val worked = DrmJobWrapper(ExecutionConfig.default, defaultUgerSettings, UgerPathBuilder, workedJob, 1)
-      val failed = DrmJobWrapper(ExecutionConfig.default, defaultUgerSettings, UgerPathBuilder, failedJob, 2)
+      val worked = DrmJobWrapper(ExecutionConfig.default, defaultUgerSettings, ugerPathBuilder, workedJob, 1)
+      val failed = DrmJobWrapper(ExecutionConfig.default, defaultUgerSettings, ugerPathBuilder, failedJob, 2)
       
       assert(workedJob.runCount === 0)
       assert(failedJob.runCount === 0)
@@ -395,7 +398,7 @@ final class DrmChunkRunnerTest extends FunSuite {
     
         DrmChunkRunner(
             environmentType = EnvironmentType.Uger,
-            pathBuilder = UgerPathBuilder,
+            pathBuilder = ugerPathBuilder,
             executionConfig = executionConfig,
             drmConfig = ugerConfig,
             jobSubmitter = mockJobSubmitter,
@@ -486,7 +489,7 @@ final class DrmChunkRunnerTest extends FunSuite {
 
         DrmChunkRunner(
             environmentType = EnvironmentType.Uger,
-            pathBuilder = UgerPathBuilder,
+            pathBuilder = ugerPathBuilder,
             executionConfig = executionConfig,
             drmConfig = ugerConfig,
             jobSubmitter = mockJobSubmitter,

--- a/src/test/scala/loamstream/drm/DrmJobWrapperTest.scala
+++ b/src/test/scala/loamstream/drm/DrmJobWrapperTest.scala
@@ -14,6 +14,7 @@ import loamstream.model.execute.DrmSettings
 import loamstream.model.execute.Environment
 import loamstream.model.jobs.commandline.CommandLineJob
 import loamstream.util.BashScript.Implicits.BashPath
+import loamstream.drm.uger.UgerScriptBuilderParams
 
 /**
  * @author clint
@@ -29,6 +30,8 @@ final class DrmJobWrapperTest extends FunSuite {
 
   private val ugerSettings = TestHelpers.defaultUgerSettings
 
+  private val ugerPathBuilder = new UgerPathBuilder(UgerScriptBuilderParams(TestHelpers.configWithUger.ugerConfig.get))
+  
   test("commandLineInTaskArray - no image") {
     val ugerSettings = TestHelpers.defaultUgerSettings
 
@@ -44,7 +47,7 @@ final class DrmJobWrapperTest extends FunSuite {
       assert(drmJob.commandLineInTaskArray === "foo")
     }
 
-    doTest(UgerPathBuilder, ugerSettings)
+    doTest(ugerPathBuilder, ugerSettings)
     doTest(LsfPathBuilder, lsfSettings)
   }
 
@@ -61,7 +64,7 @@ final class DrmJobWrapperTest extends FunSuite {
       assert(drmJob.commandLineInTaskArray === s"singularity exec ${drmSettings.containerParams.get.imageName} foo")
     }
 
-    doTest(UgerPathBuilder, ugerSettings)
+    doTest(ugerPathBuilder, ugerSettings)
     doTest(LsfPathBuilder, lsfSettings)
   }
 
@@ -87,7 +90,7 @@ final class DrmJobWrapperTest extends FunSuite {
       assert(drmJob.commandLineInTaskArray === expected)
     }
 
-    doTest(UgerPathBuilder, ugerSettings)
+    doTest(ugerPathBuilder, ugerSettings)
     doTest(LsfPathBuilder, lsfSettings)
   }
 
@@ -116,7 +119,7 @@ final class DrmJobWrapperTest extends FunSuite {
       assert(stdOutPath2 === expected2)
     }
 
-    doTest(UgerPathBuilder)
+    doTest(ugerPathBuilder)
     doTest(LsfPathBuilder)
   }
 
@@ -143,7 +146,7 @@ final class DrmJobWrapperTest extends FunSuite {
       assert(stdErrPath2 === expected2)
     }
 
-    doTest(UgerPathBuilder)
+    doTest(ugerPathBuilder)
     doTest(LsfPathBuilder)
   }
 
@@ -160,7 +163,7 @@ final class DrmJobWrapperTest extends FunSuite {
       assert(wrapper0.outputStreams.stdout === expected)
     }
 
-    doTest(UgerPathBuilder)
+    doTest(ugerPathBuilder)
     doTest(LsfPathBuilder)
   }
 
@@ -177,7 +180,7 @@ final class DrmJobWrapperTest extends FunSuite {
       assert(wrapper0.outputStreams.stderr === expected)
     }
 
-    doTest(UgerPathBuilder)
+    doTest(ugerPathBuilder)
     doTest(LsfPathBuilder)
   }
 
@@ -218,8 +221,8 @@ final class DrmJobWrapperTest extends FunSuite {
     val lsfSettingsNoContainer = TestHelpers.defaultLsfSettings
     val lsfSettingsWITHContainer = lsfSettingsNoContainer.copy(containerParams = Option(ContainerParams(imageName)))
 
-    doTest(UgerPathBuilder, ugerSettingsNoContainer, "")
-    doTest(UgerPathBuilder, ugerSettingsWITHContainer, "singularity exec fooImage.simg ")
+    doTest(ugerPathBuilder, ugerSettingsNoContainer, "")
+    doTest(ugerPathBuilder, ugerSettingsWITHContainer, "singularity exec fooImage.simg ")
 
     doTest(LsfPathBuilder, lsfSettingsNoContainer, "")
     doTest(LsfPathBuilder, lsfSettingsWITHContainer, "singularity exec fooImage.simg ")

--- a/src/test/scala/loamstream/drm/DrmTaskArrayTest.scala
+++ b/src/test/scala/loamstream/drm/DrmTaskArrayTest.scala
@@ -17,6 +17,7 @@ import loamstream.model.jobs.commandline.CommandLineJob
 import loamstream.util.BashScript.Implicits.BashPath
 import loamstream.util.Files
 import loamstream.TestHelpers
+import loamstream.drm.uger.UgerScriptBuilderParams
 
 /**
  * @author clint
@@ -56,6 +57,8 @@ final class DrmTaskArrayTest extends FunSuite {
   import DrmTaskArrayTest._
   import loamstream.TestHelpers.path
   import loamstream.TestHelpers.defaultUgerSettings
+
+  private val ugerPathBuilder = new UgerPathBuilder(UgerScriptBuilderParams(TestHelpers.configWithUger.ugerConfig.get))
   
   test("makeJobName") {
 
@@ -141,14 +144,14 @@ final class DrmTaskArrayTest extends FunSuite {
       assert(taskArray.size === jobs.size)
     }
     
-    doTest(UgerPathBuilder)
+    doTest(ugerPathBuilder)
     doTest(LsfPathBuilder)
   }
 
   test("scriptContents") {
     def doTest(drmConfig: DrmConfig): Unit = {
       //Expedient
-      val pathBuilder = if(drmConfig.isUgerConfig) UgerPathBuilder else LsfPathBuilder
+      val pathBuilder = if(drmConfig.isUgerConfig) ugerPathBuilder else LsfPathBuilder
       val scriptBuilderParams = drmConfig.scriptBuilderParams
       
       import TestHelpers.defaultUgerSettings
@@ -169,7 +172,7 @@ final class DrmTaskArrayTest extends FunSuite {
     
     def doTest(drmConfig: DrmConfig): Unit = {
       //Expedient
-      val pathBuilder = if(drmConfig.isUgerConfig) UgerPathBuilder else LsfPathBuilder
+      val pathBuilder = if(drmConfig.isUgerConfig) ugerPathBuilder else LsfPathBuilder
       val scriptBuilderParams = drmConfig.scriptBuilderParams
 
       import TestHelpers.defaultUgerSettings

--- a/src/test/scala/loamstream/drm/ScriptBuilderTest.scala
+++ b/src/test/scala/loamstream/drm/ScriptBuilderTest.scala
@@ -79,6 +79,10 @@ final class ScriptBuilderTest extends FunSuite {
 
   import loamstream.TestHelpers.path
   
+  private val ugerScriptBuilderParams = new UgerScriptBuilderParams(path("/foo/bar"), "someEnv")
+  
+  private val ugerPathBuilder = new UgerPathBuilder(ugerScriptBuilderParams)
+  
   private def defaultQueue(drmSystem: DrmSystem): Option[Queue] = drmSystem match {
     case DrmSystem.Lsf => None
     case DrmSystem.Uger => Some(Queue("broad"))
@@ -91,12 +95,12 @@ final class ScriptBuilderTest extends FunSuite {
   
   private def pathBuilder(drmSystem: DrmSystem): PathBuilder = drmSystem match {
     case DrmSystem.Lsf => LsfPathBuilder
-    case DrmSystem.Uger => UgerPathBuilder
+    case DrmSystem.Uger => ugerPathBuilder
   }
   
   private def scriptBuilderParams(drmSystem: DrmSystem): ScriptBuilderParams = drmSystem match {
     case DrmSystem.Lsf => LsfScriptBuilderParams
-    case DrmSystem.Uger => UgerScriptBuilderParams
+    case DrmSystem.Uger => ugerScriptBuilderParams
   }
 
   private def getShapeItCommandLineJob(discriminator: Int): CommandLineJob = {
@@ -179,8 +183,8 @@ final class ScriptBuilderTest extends FunSuite {
                                 |reuse -q UGER
                                 |reuse -q Java-1.8
                                 |
-                                |export PATH=/humgen/diabetes/users/dig/miniconda2/bin:$PATH
-                                |source activate loamstream_v1.0
+                                |export PATH=/foo/bar:$PATH
+                                |source activate someEnv
                                 |
                                 |mkdir -p /broad/hptmp/${USER}
                                 |export SINGULARITY_CACHEDIR=/broad/hptmp/${USER}

--- a/src/test/scala/loamstream/drm/uger/UgerPathBuilderTest.scala
+++ b/src/test/scala/loamstream/drm/uger/UgerPathBuilderTest.scala
@@ -17,30 +17,52 @@ final class UgerPathBuilderTest extends FunSuite {
   import loamstream.TestHelpers.path
   import loamstream.util.BashScript.Implicits._
   
-  private val workDir = TestHelpers.path("/foo/bar/baz").toAbsolutePath
+  private val workDir = path("/foo/bar/baz").toAbsolutePath
 
   private val ugerConfig = UgerConfig(workDir = workDir, maxNumJobs = 42)
   
+  private val someDir = path("/some/dir")
+  
+  private val someEnv = "someEnv"
+  
   test("reifyPathTemplate") {
+    val params = new UgerScriptBuilderParams(someDir, someEnv)
+    
+    val pathBuilder = new UgerPathBuilder(params)
+    
     val template = {
-      s":::/foo/bar/${UgerScriptBuilderParams.drmIndexVarExpr}/baz.${UgerScriptBuilderParams.drmIndexVarExpr}"
+      s":::/foo/bar/${params.drmIndexVarExpr}/baz.${params.drmIndexVarExpr}"
     }
     
-    assert(UgerPathBuilder.reifyPathTemplate(template, 42) === path("/foo/bar/42/baz.42").toAbsolutePath)
+    assert(pathBuilder.reifyPathTemplate(template, 42) === path("/foo/bar/42/baz.42").toAbsolutePath)
   }
   
   test("pathTemplatePrefix") {
-    assert(UgerPathBuilder.pathTemplatePrefix === ":")
+    val params = new UgerScriptBuilderParams(someDir, someEnv)
+    
+    val pathBuilder = new UgerPathBuilder(params)
+    
+    assert(pathBuilder.pathTemplatePrefix === ":")
   }
   
   test("ugerStdOutPathTemplate") {
+    val params = new UgerScriptBuilderParams(someDir, someEnv)
+    
+    val pathBuilder = new UgerPathBuilder(params)
+    
     val expected = workDir.resolve(s"blarg-blahblah.${JobTemplate.PARAMETRIC_INDEX}.stdout")
-    doPathTemplateTest(UgerPathBuilder.stdOutPathTemplate, s":${expected.render}")
+    
+    doPathTemplateTest(pathBuilder.stdOutPathTemplate, s":${expected.render}")
   }
 
   test("ugerStdErrPathTemplate") {
+    val params = new UgerScriptBuilderParams(someDir, someEnv)
+    
+    val pathBuilder = new UgerPathBuilder(params)
+    
     val expected = workDir.resolve(s"blarg-blahblah.${JobTemplate.PARAMETRIC_INDEX}.stderr")
-    doPathTemplateTest(UgerPathBuilder.stdErrPathTemplate, s":${expected.render}")
+    
+    doPathTemplateTest(pathBuilder.stdErrPathTemplate, s":${expected.render}")
   }
 
   private def doPathTemplateTest(makeTemplate: (DrmConfig, String) => String, expected: String): Unit = {

--- a/src/test/scala/loamstream/drm/uger/UgerScriptBuilderParamsTest.scala
+++ b/src/test/scala/loamstream/drm/uger/UgerScriptBuilderParamsTest.scala
@@ -1,6 +1,7 @@
 package loamstream.drm.uger
 
 import org.scalatest.FunSuite
+import loamstream.TestHelpers
 
 
 /**
@@ -8,8 +9,16 @@ import org.scalatest.FunSuite
  * May 11, 2018
  */
 final class UgerScriptBuilderParamsTest extends FunSuite {
+  import TestHelpers.path
+  
+  private val someDir = path("/some/dir")
+  
+  private val someEnv = "someEnv"
+  
   test("drmIndexVarExpr") {
-    assert(UgerScriptBuilderParams.drmIndexVarExpr === "$drmaa_incr_ph$")
+    val params = new UgerScriptBuilderParams(someDir, someEnv)
+    
+    assert(params.drmIndexVarExpr === "$drmaa_incr_ph$")
   }
   
   test("preamble") {
@@ -19,20 +28,26 @@ final class UgerScriptBuilderParamsTest extends FunSuite {
                       |reuse -q UGER
                       |reuse -q Java-1.8
                       |
-                      |export PATH=/humgen/diabetes/users/dig/miniconda2/bin:$PATH
-                      |source activate loamstream_v1.0
+                      |export PATH=/some/dir:$PATH
+                      |source activate someEnv
                       |
                       |mkdir -p /broad/hptmp/${USER}
                       |export SINGULARITY_CACHEDIR=/broad/hptmp/${USER}""".stripMargin
     
-    assert(UgerScriptBuilderParams.preamble === Some(expected))
+    val params = new UgerScriptBuilderParams(someDir, someEnv)
+                      
+    assert(params.preamble === Some(expected))
   }
   
   test("indexEnvVarName") {
-    assert(UgerScriptBuilderParams.indexEnvVarName === "SGE_TASK_ID")
+    val params = new UgerScriptBuilderParams(someDir, someEnv)
+    
+    assert(params.indexEnvVarName === "SGE_TASK_ID")
   }
   
   test("jobIdEnvVarName") {
-    assert(UgerScriptBuilderParams.jobIdEnvVarName === "JOB_ID")
+    val params = new UgerScriptBuilderParams(someDir, someEnv)
+    
+    assert(params.jobIdEnvVarName === "JOB_ID")
   }
 }


### PR DESCRIPTION
- Allows configuring Conda bin path and the Conda environment to activate in scripts submitted to Uger.
- Added `extraPathDir` and `condaEnvName` to `loamstream.uger` section of `loamstream.conf`:
```
loamstream {
  ...
  uger {
    ...
    extraPathDir = "/humgen/diabetes/users/dig/miniconda2/bin"
    condaEnvName = "loamstream_v1.0"
  }
  ...
}
```
- `UgerScriptBuilderParams` and `UgerPathBuilder` now take params.

Note: The integration tests passed.