### PR TITLE
Allow Configuring Uger native spec in loamstream.conf

### DIFF
--- a/src/main/scala/loamstream/apps/AppWiring.scala
+++ b/src/main/scala/loamstream/apps/AppWiring.scala
@@ -364,7 +364,7 @@ object AppWiring extends Loggable {
     } yield {
       debug("Creating Uger ChunkRunner...")
 
-      val ugerClient = makeUgerClient
+      val ugerClient = makeUgerClient(ugerConfig)
 
       import loamstream.model.execute.ExecuterHelpers._
 
@@ -433,8 +433,8 @@ object AppWiring extends Loggable {
     }
   }
   
-  private def makeUgerClient: DrmClient = {
-    val drmaa1Client = new Drmaa1Client(UgerResourceUsageExtractor, UgerNativeSpecBuilder)
+  private def makeUgerClient(ugerConfig: UgerConfig): DrmClient = {
+    val drmaa1Client = new Drmaa1Client(UgerResourceUsageExtractor, UgerNativeSpecBuilder(ugerConfig))
     
     new DrmClient(drmaa1Client, QacctAccountingClient.useActualBinary())
   }

--- a/src/main/scala/loamstream/conf/DrmConfig.scala
+++ b/src/main/scala/loamstream/conf/DrmConfig.scala
@@ -51,7 +51,8 @@ final case class UgerConfig(
     defaultMemoryPerCore: Memory = UgerDefaults.memoryPerCore,
     defaultMaxRunTime: CpuTime = UgerDefaults.maxRunTime,
     extraPathDir: Path = UgerDefaults.extraPathDir,
-    condaEnvName: String = UgerDefaults.condaEnvName) extends DrmConfig {
+    condaEnvName: String = UgerDefaults.condaEnvName,
+    staticJobSubmissionParams: String = UgerDefaults.staticJobSubmissionParams) extends DrmConfig {
   
   override def scriptBuilderParams: ScriptBuilderParams = new UgerScriptBuilderParams(extraPathDir, condaEnvName)
 }

--- a/src/main/scala/loamstream/drm/uger/UgerDefaults.scala
+++ b/src/main/scala/loamstream/drm/uger/UgerDefaults.scala
@@ -25,4 +25,6 @@ object UgerDefaults {
   val extraPathDir: Path = Paths.get("/humgen/diabetes/users/dig/miniconda2/bin")
 
   val condaEnvName: String = "loamstream_v1.0"
+  
+  val staticJobSubmissionParams: String = "-cwd -shell y -b n"
 }

--- a/src/main/scala/loamstream/drm/uger/UgerNativeSpecBuilder.scala
+++ b/src/main/scala/loamstream/drm/uger/UgerNativeSpecBuilder.scala
@@ -10,12 +10,12 @@ import loamstream.conf.UgerConfig
  * May 11, 2018
  */
 final case class UgerNativeSpecBuilder(ugerConfig: UgerConfig) extends NativeSpecBuilder {
-  override def toNativeSpec(ugerSettings: DrmSettings): String = {
+  override def toNativeSpec(drmSettings: DrmSettings): String = {
 
     val staticPart = ugerConfig.staticJobSubmissionParams
 
     val dynamicPart = {
-      import ugerSettings._
+      import drmSettings._
 
       val numCores = cores.value
       val runTimeInHours: Int = maxRunTime.hours.toInt
@@ -23,7 +23,7 @@ final case class UgerNativeSpecBuilder(ugerConfig: UgerConfig) extends NativeSpe
 
       val queuePart = queue.map(q => s"-q $q").getOrElse("")
       
-      val osPart = ugerSettings.containerParams match {
+      val osPart = drmSettings.containerParams match {
         case Some(_) => "-l os=RedHat7"
         case None => ""
       }

--- a/src/main/scala/loamstream/drm/uger/UgerNativeSpecBuilder.scala
+++ b/src/main/scala/loamstream/drm/uger/UgerNativeSpecBuilder.scala
@@ -2,18 +2,20 @@ package loamstream.drm.uger
 
 import loamstream.drm.NativeSpecBuilder
 import loamstream.model.execute.DrmSettings
+import loamstream.model.execute.UgerDrmSettings
+import loamstream.conf.UgerConfig
 
 /**
  * @author clint
  * May 11, 2018
  */
-object UgerNativeSpecBuilder extends NativeSpecBuilder {
-  override def toNativeSpec(drmSettings: DrmSettings): String = {
-    //Will this ever change?
-    val staticPart = "-cwd -shell y -b n"
+final case class UgerNativeSpecBuilder(ugerConfig: UgerConfig) extends NativeSpecBuilder {
+  override def toNativeSpec(ugerSettings: DrmSettings): String = {
+
+    val staticPart = ugerConfig.staticJobSubmissionParams
 
     val dynamicPart = {
-      import drmSettings._
+      import ugerSettings._
 
       val numCores = cores.value
       val runTimeInHours: Int = maxRunTime.hours.toInt
@@ -21,7 +23,7 @@ object UgerNativeSpecBuilder extends NativeSpecBuilder {
 
       val queuePart = queue.map(q => s"-q $q").getOrElse("")
       
-      val osPart = drmSettings.containerParams match {
+      val osPart = ugerSettings.containerParams match {
         case Some(_) => "-l os=RedHat7"
         case None => ""
       }

--- a/src/main/scala/loamstream/drm/uger/UgerScriptBuilderParams.scala
+++ b/src/main/scala/loamstream/drm/uger/UgerScriptBuilderParams.scala
@@ -10,14 +10,15 @@ import loamstream.conf.UgerConfig
  * May 11, 2018
  */
 final case class UgerScriptBuilderParams(extraPathDir: Path, condaEnvName: String) extends ScriptBuilderParams {
-  
+  import loamstream.util.BashScript.Implicits._
+
   /*
    * We need to 'use' Java-1.8 to make some steps of the QC pipeline work.
-   * 
-   * Set SINGULARITY_CACHEDIR to something other than the default, under 
-   * ~/.singularity, which will cause quota problems.  Follow recommendations 
-   * from BITS at 
-   * https://broad.service-now.com/nav_to.do?uri=%2Fkb_view.do%3Fsysparm_article%3DKB0010821 
+   *
+   * Set SINGULARITY_CACHEDIR to something other than the default, under
+   * ~/.singularity, which will cause quota problems.  Follow recommendations
+   * from BITS at
+   * https://broad.service-now.com/nav_to.do?uri=%2Fkb_view.do%3Fsysparm_article%3DKB0010821
    */
   private def ugerPreamble = s"""|#$$ -cwd
                                  |
@@ -25,14 +26,14 @@ final case class UgerScriptBuilderParams(extraPathDir: Path, condaEnvName: Strin
                                  |reuse -q UGER
                                  |reuse -q Java-1.8
                                  |
-                                 |export PATH=${extraPathDir}:$$PATH
+                                 |export PATH=${extraPathDir.render}:$$PATH
                                  |source activate ${condaEnvName}
                                  |
                                  |mkdir -p /broad/hptmp/$${USER}
                                  |export SINGULARITY_CACHEDIR=/broad/hptmp/$${USER}""".stripMargin
-  
-  override val preamble: Option[String] = Option(ugerPreamble) 
-  override val indexEnvVarName: String = "SGE_TASK_ID" 
+
+  override val preamble: Option[String] = Option(ugerPreamble)
+  override val indexEnvVarName: String = "SGE_TASK_ID"
   override val jobIdEnvVarName: String = "JOB_ID"
   override val drmIndexVarExpr: String = JobTemplate.PARAMETRIC_INDEX
 }

--- a/src/main/scala/loamstream/model/execute/Settings.scala
+++ b/src/main/scala/loamstream/model/execute/Settings.scala
@@ -57,13 +57,15 @@ final case class LsfDrmSettings(
 object DrmSettings {
   type SettingsMaker = (Cpus, Memory, CpuTime, Option[Queue], Option[ContainerParams]) => DrmSettings
   
-  def unapply(settings: DrmSettings): Option[(Cpus, Memory, CpuTime, Option[Queue], Option[ContainerParams])] = {
+  type FieldsTuple = (Cpus, Memory, CpuTime, Option[Queue], Option[ContainerParams])
+  
+  def unapply(settings: DrmSettings): Option[FieldsTuple] = {
     import settings._
     
-    Some(cores, memoryPerCore, maxRunTime, queue, containerParams)
+    Some((cores, memoryPerCore, maxRunTime, queue, containerParams))
   }
   
-  def fromUgerConfig(config: UgerConfig): DrmSettings = {
+  def fromUgerConfig(config: UgerConfig): UgerDrmSettings = {
     UgerDrmSettings(
         config.defaultCores, 
         config.defaultMemoryPerCore, 
@@ -72,7 +74,7 @@ object DrmSettings {
         None)
   }
   
-  def fromLsfConfig(config: LsfConfig): DrmSettings = {
+  def fromLsfConfig(config: LsfConfig): LsfDrmSettings = {
     LsfDrmSettings(config.defaultCores, config.defaultMemoryPerCore, config.defaultMaxRunTime, None, None)
   }
 }

--- a/src/test/scala/loamstream/apps/AppWiringTest.scala
+++ b/src/test/scala/loamstream/apps/AppWiringTest.scala
@@ -1,27 +1,28 @@
 package loamstream.apps
 
-import org.scalatest.FunSuite
 import java.nio.file.Paths
-import loamstream.cli.Conf
+
+import org.scalatest.FunSuite
 import org.scalatest.Matchers
-import loamstream.db.slick.SlickLoamDao
-import loamstream.model.execute.RxExecuter
-import loamstream.model.execute.DbBackedJobFilter
-import loamstream.model.execute.JobFilter
-import loamstream.model.execute.AsyncLocalChunkRunner
-import loamstream.model.execute.CompositeChunkRunner
-import loamstream.model.execute.HashingStrategy
+
+import loamstream.cli.Conf
 import loamstream.cli.Intent
-import loamstream.TestHelpers
-import loamstream.db.slick.DbDescriptor
-import loamstream.drm.DrmSystem
-import loamstream.drm.DrmChunkRunner
-import loamstream.model.execute.ByNameJobFilter
 import loamstream.conf.LoamConfig
+import loamstream.db.slick.DbDescriptor
+import loamstream.db.slick.SlickLoamDao
+import loamstream.drm.DrmChunkRunner
+import loamstream.drm.DrmSystem
+import loamstream.drm.PathBuilder
 import loamstream.drm.lsf.LsfPathBuilder
 import loamstream.drm.uger.UgerPathBuilder
-import loamstream.drm.PathBuilder
 import loamstream.drm.uger.UgerScriptBuilderParams
+import loamstream.model.execute.AsyncLocalChunkRunner
+import loamstream.model.execute.ByNameJobFilter
+import loamstream.model.execute.CompositeChunkRunner
+import loamstream.model.execute.DbBackedJobFilter
+import loamstream.model.execute.JobFilter
+import loamstream.model.execute.RxExecuter
+
 
 
 /**
@@ -217,6 +218,4 @@ final class AppWiringTest extends FunSuite with Matchers {
     doTest(Some(DrmSystem.Uger))
     doTest(Some(DrmSystem.Lsf))
   }
-  
-  
 }

--- a/src/test/scala/loamstream/conf/UgerConfigTest.scala
+++ b/src/test/scala/loamstream/conf/UgerConfigTest.scala
@@ -29,6 +29,7 @@ final class UgerConfigTest extends FunSuite {
     assert(config.defaultMaxRunTime === UgerDefaults.maxRunTime)
     assert(config.extraPathDir === UgerDefaults.extraPathDir)
     assert(config.condaEnvName === UgerDefaults.condaEnvName)
+    assert(config.staticJobSubmissionParams === UgerDefaults.staticJobSubmissionParams)
   }
   
   test("Parsing bad input should fail") {
@@ -50,6 +51,7 @@ final class UgerConfigTest extends FunSuite {
           defaultMaxRunTime = 11 // hours
           extraPathDir = /blah/baz
           condaEnvName = fooEnv
+          staticJobSubmissionParams = "foo bar baz"
         }
       }
       """)
@@ -63,6 +65,7 @@ final class UgerConfigTest extends FunSuite {
     assert(ugerConfig.defaultMaxRunTime === CpuTime.inHours(11))
     assert(ugerConfig.extraPathDir === path("/blah/baz"))
     assert(ugerConfig.condaEnvName === "fooEnv")
+    assert(ugerConfig.staticJobSubmissionParams === "foo bar baz")
   }
   
   test("Parsing a UgerConfig with optional values omitted should work") {
@@ -83,5 +86,6 @@ final class UgerConfigTest extends FunSuite {
     assert(ugerConfig.defaultMaxRunTime === UgerDefaults.maxRunTime)
     assert(ugerConfig.extraPathDir === UgerDefaults.extraPathDir)
     assert(ugerConfig.condaEnvName === UgerDefaults.condaEnvName)
+    assert(ugerConfig.staticJobSubmissionParams === UgerDefaults.staticJobSubmissionParams)
   }
 }

--- a/src/test/scala/loamstream/drm/uger/UgerScriptBuilderParamsTest.scala
+++ b/src/test/scala/loamstream/drm/uger/UgerScriptBuilderParamsTest.scala
@@ -3,51 +3,51 @@ package loamstream.drm.uger
 import org.scalatest.FunSuite
 import loamstream.TestHelpers
 
-
 /**
  * @author clint
  * May 11, 2018
  */
 final class UgerScriptBuilderParamsTest extends FunSuite {
   import TestHelpers.path
-  
+  import loamstream.util.BashScript.Implicits._
+
   private val someDir = path("/some/dir")
-  
+
   private val someEnv = "someEnv"
-  
+
   test("drmIndexVarExpr") {
     val params = new UgerScriptBuilderParams(someDir, someEnv)
-    
+
     assert(params.drmIndexVarExpr === "$drmaa_incr_ph$")
   }
-  
+
   test("preamble") {
-    val expected = """|#$ -cwd
-                      |
-                      |source /broad/software/scripts/useuse
-                      |reuse -q UGER
-                      |reuse -q Java-1.8
-                      |
-                      |export PATH=/some/dir:$PATH
-                      |source activate someEnv
-                      |
-                      |mkdir -p /broad/hptmp/${USER}
-                      |export SINGULARITY_CACHEDIR=/broad/hptmp/${USER}""".stripMargin
-    
+    val expected = s"""|#$$ -cwd
+                       |
+                       |source /broad/software/scripts/useuse
+                       |reuse -q UGER
+                       |reuse -q Java-1.8
+                       |
+                       |export PATH=${someDir.render}:$$PATH
+                       |source activate someEnv
+                       |
+                       |mkdir -p /broad/hptmp/$${USER}
+                       |export SINGULARITY_CACHEDIR=/broad/hptmp/$${USER}""".stripMargin
+
     val params = new UgerScriptBuilderParams(someDir, someEnv)
-                      
+
     assert(params.preamble === Some(expected))
   }
-  
+
   test("indexEnvVarName") {
     val params = new UgerScriptBuilderParams(someDir, someEnv)
-    
+
     assert(params.indexEnvVarName === "SGE_TASK_ID")
   }
-  
+
   test("jobIdEnvVarName") {
     val params = new UgerScriptBuilderParams(someDir, someEnv)
-    
+
     assert(params.jobIdEnvVarName === "JOB_ID")
   }
 }


### PR DESCRIPTION
Previously, the "native spec", a set of flags analagous to `qsub` params, used when submitting Uger jobs was hard-coded.  This PR makes it configurable in `loamstream.conf`.

- `loamstream.conf` now allows an optional string, `loamstream.uger.staticJobSubmissionParams`.  If this is not present, the previously hard-coded value - `-cwd -shell y -b n` is used.
- If it's present, its value forms the beginning of the native spec that's passed to Uger, not the whole thing.  As before, the rest is built dynamically from job-specific settings (number of cores, memory, max runtime, etc).

NOTE: The Uger integration tests passed.  This should be merged *after* #310 .