### PR TITLE
De-dupe JobRuns in RxExecuter based on their jobs' ids and run counts

### DIFF
--- a/src/main/scala/loamstream/compiler/LoamCompiler.scala
+++ b/src/main/scala/loamstream/compiler/LoamCompiler.scala
@@ -139,7 +139,9 @@ object LoamCompiler extends Loggable {
         val soManyWarnings = soMany(warnings.size, "warning")
         val soManyInfos = soMany(infos.size, "info")
         
-        s"There were $soManyErrors, $soManyWarnings, $soManyInfos. ${throwable.getClass.getName} caught: ${throwable.getMessage}"
+        val throwableClass = throwable.getClass.getName
+        
+        s"There were $soManyErrors, $soManyWarnings, $soManyInfos. ${throwableClass} caught: ${throwable.getMessage}"
       }
     }
   }

--- a/src/main/scala/loamstream/model/execute/RxExecuter.scala
+++ b/src/main/scala/loamstream/model/execute/RxExecuter.scala
@@ -59,13 +59,10 @@ final case class RxExecuter(
     //An Observable stream of job runs; each job is emitted when it becomes runnable.  This can be because the
     //job's dependencies finished successfully, or because the job failed and we've decided to restart it.
     //
-    //Previously, job runs were de-duped here with .distinct, but this caused too much memory to be used, especially
-    //in the case of "diamond-shaped" topologies.  (This was always the case, but the issue became more acute when
-    //processing the FUSION dataset - which led to a larger and more complex topology of jobs - and when JobNode was
-    //switched to using caching observables.  The latter in particular led to combinatorial explosions in the number
-    //of job run objects in some cases.  De-duping here worked, but was "too late" - the damage in terms of heap
-    //usage had already been done.
-    val runnables: Observable[JobRun] = executable.multiplex(_.runnables)
+    //De-dupe jobs based on their ids and run counts.  This allows for re-running failed jobs, since while the
+    //job id would stay the same in that case, the run count would differ.  This is a blunt-force method that 
+    //prevents running the same job more than once concurrently in the face of "diamond-shaped" topologies.  
+    val runnables: Observable[JobRun] = executable.multiplex(_.runnables).distinct(_.key)
     
     //An observable stream of "chunks" of runnable jobs, with each chunk represented as a Seq.
     //Jobs are buffered up until the amount of time indicated by 'windowLength' elapses, or 'runner.maxNumJobs'

--- a/src/main/scala/loamstream/model/execute/RxExecuter.scala
+++ b/src/main/scala/loamstream/model/execute/RxExecuter.scala
@@ -61,7 +61,7 @@ final case class RxExecuter(
     //
     //De-dupe jobs based on their ids and run counts.  This allows for re-running failed jobs, since while the
     //job id would stay the same in that case, the run count would differ.  This is a blunt-force method that 
-    //prevents running the same job more than once concurrently in the face of "diamond-shaped" topologies.; unsurprisingly,   
+    //prevents running the same job more than once concurrently in the face of "diamond-shaped" topologies.
     val runnables: Observable[JobRun] = RxExecuter.deDupe(executable.multiplex(_.runnables))
     
     //An observable stream of "chunks" of runnable jobs, with each chunk represented as a Seq.

--- a/src/main/scala/loamstream/model/jobs/JobRun.scala
+++ b/src/main/scala/loamstream/model/jobs/JobRun.scala
@@ -22,7 +22,7 @@ final class JobRun(val job: LJob, val status: JobStatus, val runCount: Int) {
   
   override def hashCode: Int = Seq(job, status, runCount).hashCode
   
-  def key: (Int, Int) = (job.id, runCount)
+  def key: (Int, JobStatus, Int) = (job.id, status, runCount)
 }
 
 object JobRun {

--- a/src/main/scala/loamstream/model/jobs/JobRun.scala
+++ b/src/main/scala/loamstream/model/jobs/JobRun.scala
@@ -21,6 +21,8 @@ final class JobRun(val job: LJob, val status: JobStatus, val runCount: Int) {
   }
   
   override def hashCode: Int = Seq(job, status, runCount).hashCode
+  
+  def key: (Int, Int) = (job.id, runCount)
 }
 
 object JobRun {

--- a/src/test/scala/loamstream/model/execute/RxExecuterTest.scala
+++ b/src/test/scala/loamstream/model/execute/RxExecuterTest.scala
@@ -71,7 +71,6 @@ final class RxExecuterTest extends FunSuite {
     import TestHelpers.waitFor
     import Observables.Implicits._
     
-    
     val job1 = RxMockJob("Job_1")
     val job2 = RxMockJob("Job_2")
     val job3 = RxMockJob("Job_3")
@@ -82,7 +81,7 @@ final class RxExecuterTest extends FunSuite {
     
     val someDupes = Seq(
         JobRun(job1, NotStarted, 1), 
-        JobRun(job1, Skipped, 1),
+        JobRun(job1, NotStarted, 1),
         JobRun(job2, Running, 99),
         JobRun(job3, Running, 42),
         JobRun(job2, Running, 99))

--- a/src/test/scala/loamstream/model/jobs/JobRunTest.scala
+++ b/src/test/scala/loamstream/model/jobs/JobRunTest.scala
@@ -16,13 +16,13 @@ final class JobRunTest extends FunSuite {
     
     assert(job0.id != job1.id)
     
-    assert(JobRun(job0, Submitted, 42).key === (job0.id, 42))
-    assert(JobRun(job1, Submitted, 42).key === (job1.id, 42))
-    assert(JobRun(job1, Submitted, 99).key === (job1.id, 99))
+    assert(JobRun(job0, Submitted, 42).key === (job0.id, Submitted, 42))
+    assert(JobRun(job1, Submitted, 42).key === (job1.id, Submitted, 42))
+    assert(JobRun(job1, Submitted, 99).key === (job1.id, Submitted, 99))
     
-    assert(JobRun(job0, Running, 42).key === (job0.id, 42))
-    assert(JobRun(job0, Skipped, 42).key === (job0.id, 42))
-    assert(JobRun(job0, Failed, 42).key === (job0.id, 42))
+    assert(JobRun(job0, Running, 42).key === (job0.id, Running, 42))
+    assert(JobRun(job0, Skipped, 42).key === (job0.id, Skipped, 42))
+    assert(JobRun(job0, Failed, 42).key === (job0.id, Failed, 42))
   }
   
   test("toString") {

--- a/src/test/scala/loamstream/model/jobs/JobRunTest.scala
+++ b/src/test/scala/loamstream/model/jobs/JobRunTest.scala
@@ -10,6 +10,21 @@ final class JobRunTest extends FunSuite {
 
   import JobStatus._
   
+  test("key") {
+    val job0 = RxMockJob("foo")
+    val job1 = RxMockJob("bar")
+    
+    assert(job0.id != job1.id)
+    
+    assert(JobRun(job0, Submitted, 42).key === (job0.id, 42))
+    assert(JobRun(job1, Submitted, 42).key === (job1.id, 42))
+    assert(JobRun(job1, Submitted, 99).key === (job1.id, 99))
+    
+    assert(JobRun(job0, Running, 42).key === (job0.id, 42))
+    assert(JobRun(job0, Skipped, 42).key === (job0.id, 42))
+    assert(JobRun(job0, Failed, 42).key === (job0.id, 42))
+  }
+  
   test("toString") {
     val job = RxMockJob("foo")
     


### PR DESCRIPTION
- Fix a bug where in complex pipelines, duplicates of the same job would be run concurrently.  This happened non-deterministically, but required there to be multiple paths from a root job to another job in the graph.  There was/is a race where the same job can become runnable via multiple paths.  This fix just de-dupes runnable jobs after the streams of runnable jobs reached via all paths are multiplexed.

It's simple, but doesn't address the root cause, which is treating the graph of jobs as a forest of job trees.  The comments also reflect that a previous call to `.distinct` in the same place led to spiraling memory use before.  This version actually uses much _less_ memory according to my profiler when wiring up and running the BioMe pipeline (the worst-case scenario in terms of number of jobs and overall topological complexity).  Besides that it doesn't address root causes, the comment about the downside of calling `distinct` in `RxExecuter.execute` made me hesitant to make this change at first.

In any case, I didn't observe any duplicate jobs when running Ryan's pipeline with the BioMe config for ~20 hours.  Running the same pipeline and config with the code in master showed duplicate jobs within an hour, so I'm willing to say this fixed the problem.  The unit and integration tests also passed when run by Jenkins.