### PR TITLE
Use G instead of g when specifying memory requests to Uger.

### DIFF
--- a/src/main/scala/loamstream/drm/uger/UgerNativeSpecBuilder.scala
+++ b/src/main/scala/loamstream/drm/uger/UgerNativeSpecBuilder.scala
@@ -28,7 +28,7 @@ final case class UgerNativeSpecBuilder(ugerConfig: UgerConfig) extends NativeSpe
         case None => ""
       }
       
-      val memPart = s"h_vmem=${mem}g"
+      val memPart = s"h_vmem=${mem}G"
       
       val runTimePart = s"h_rt=${runTimeInHours}:0:0"
       

--- a/src/test/scala/loamstream/drm/uger/UgerNativeSpecBuilderTest.scala
+++ b/src/test/scala/loamstream/drm/uger/UgerNativeSpecBuilderTest.scala
@@ -44,7 +44,7 @@ final class UgerNativeSpecBuilderTest extends FunSuite {
         val actualNativeSpec = getNativeSpec(ugerConfig)
        
         val expected = {
-          s"-cwd -shell y -b n -binding linear:42 -pe smp 42 -q broad -l h_rt=33:0:0,h_vmem=17g $expectedOsPart"
+          s"-cwd -shell y -b n -binding linear:42 -pe smp 42 -q broad -l h_rt=33:0:0,h_vmem=17G $expectedOsPart"
         }
         
         assert(actualNativeSpec === expected)
@@ -56,7 +56,7 @@ final class UgerNativeSpecBuilderTest extends FunSuite {
         val actualNativeSpec = getNativeSpec(nonDefaultUgerConfig)
        
         val expected = {
-          s"foo bar baz -binding linear:42 -pe smp 42 -q broad -l h_rt=33:0:0,h_vmem=17g $expectedOsPart"
+          s"foo bar baz -binding linear:42 -pe smp 42 -q broad -l h_rt=33:0:0,h_vmem=17G $expectedOsPart"
         }
         
         assert(actualNativeSpec === expected)


### PR DESCRIPTION
- This asks for gigabytes instead of gibibytes.

The unit and integration tests passed when run by Jenkins.