### PR TITLE
Retry Qacct a configurable number of times if it fails

### DIFF
--- a/src/main/scala/loamstream/apps/AppWiring.scala
+++ b/src/main/scala/loamstream/apps/AppWiring.scala
@@ -449,7 +449,7 @@ object AppWiring extends Loggable {
   private def makeUgerClient(ugerConfig: UgerConfig): DrmClient = {
     val drmaa1Client = new Drmaa1Client(UgerResourceUsageExtractor, UgerNativeSpecBuilder(ugerConfig))
     
-    new DrmClient(drmaa1Client, QacctAccountingClient.useActualBinary())
+    new DrmClient(drmaa1Client, QacctAccountingClient.useActualBinary(ugerConfig))
   }
   
   private def loadConfig(confFileOpt: Option[Path]): Config = {

--- a/src/main/scala/loamstream/conf/DrmConfig.scala
+++ b/src/main/scala/loamstream/conf/DrmConfig.scala
@@ -56,7 +56,8 @@ final case class UgerConfig(
     defaultMaxRunTime: CpuTime = UgerDefaults.maxRunTime,
     extraPathDir: Path = UgerDefaults.extraPathDir,
     condaEnvName: String = UgerDefaults.condaEnvName,
-    staticJobSubmissionParams: String = UgerDefaults.staticJobSubmissionParams) extends DrmConfig {
+    staticJobSubmissionParams: String = UgerDefaults.staticJobSubmissionParams,
+    maxQacctRetries: Int =  UgerDefaults.maxQacctRetries) extends DrmConfig {
   
   override def scriptBuilderParams: ScriptBuilderParams = new UgerScriptBuilderParams(extraPathDir, condaEnvName)
 }
@@ -70,7 +71,8 @@ object UgerConfig extends ConfigParser[UgerConfig] with Loggable {
     defaultMaxRunTime: CpuTime = UgerDefaults.maxRunTime,
     extraPathDir: Path = UgerDefaults.extraPathDir,
     condaEnvName: String = UgerDefaults.condaEnvName,
-    staticJobSubmissionParams: String = UgerDefaults.staticJobSubmissionParams) {
+    staticJobSubmissionParams: String = UgerDefaults.staticJobSubmissionParams,
+    maxQacctRetries: Int =  UgerDefaults.maxQacctRetries) {
     
     def toUgerConfig: UgerConfig = UgerConfig(
       maxNumJobs = maxNumJobs,
@@ -79,7 +81,8 @@ object UgerConfig extends ConfigParser[UgerConfig] with Loggable {
       defaultMaxRunTime = defaultMaxRunTime,
       extraPathDir = extraPathDir,
       condaEnvName = condaEnvName,
-      staticJobSubmissionParams = staticJobSubmissionParams)
+      staticJobSubmissionParams = staticJobSubmissionParams,
+      maxQacctRetries = maxQacctRetries)
   }
   
   override def fromConfig(config: Config): Try[UgerConfig] = {

--- a/src/main/scala/loamstream/drm/uger/QacctAccountingClient.scala
+++ b/src/main/scala/loamstream/drm/uger/QacctAccountingClient.scala
@@ -54,14 +54,19 @@ final class QacctAccountingClient(
       attempts.toStream.headOption match {
         case Some(Success(lines)) => lines
         case Some(Failure(e)) => {
-          debug(s"Error invoking qacct; execution stats won't be available: $e")
+          debug(s"Error invoking qacct for job with DRM id '$jobId'; execution stats won't be available: $e")
 
           trace(s"qacct invocation failure stack trace:", e)
 
           Seq.empty
         }
         case None => {
-          debug(s"Invoking qacct failed after $maxRuns runs; execution stats won't be available")
+          val msg = {
+            s"Invoking qacct for job with DRM id '$jobId' failed after $maxRuns runs; " +
+             "execution stats won't be available"
+          }
+          
+          debug(msg)
 
           Seq.empty
         }

--- a/src/main/scala/loamstream/drm/uger/UgerDefaults.scala
+++ b/src/main/scala/loamstream/drm/uger/UgerDefaults.scala
@@ -27,4 +27,6 @@ object UgerDefaults {
   val condaEnvName: String = "loamstream_v1.0"
   
   val staticJobSubmissionParams: String = "-cwd -shell y -b n"
+  
+  val maxQacctRetries: Int = 9
 }

--- a/src/test/scala/loamstream/conf/UgerConfigTest.scala
+++ b/src/test/scala/loamstream/conf/UgerConfigTest.scala
@@ -29,6 +29,7 @@ final class UgerConfigTest extends FunSuite {
     assert(config.extraPathDir === UgerDefaults.extraPathDir)
     assert(config.condaEnvName === UgerDefaults.condaEnvName)
     assert(config.staticJobSubmissionParams === UgerDefaults.staticJobSubmissionParams)
+    assert(config.maxQacctRetries === UgerDefaults.maxQacctRetries)
   }
   
   test("Parsing a UgerConfig with all values provided should work") {
@@ -42,21 +43,23 @@ final class UgerConfigTest extends FunSuite {
           extraPathDir = /blah/baz
           condaEnvName = fooEnv
           staticJobSubmissionParams = "foo bar baz"
+          maxQacctRetries = 123
         }
       }
       """)
       
-    val ugerConfig = UgerConfig.fromConfig(valid).get
+    val config = UgerConfig.fromConfig(valid).get
     
-    assert(ugerConfig.workDir === Locations.ugerDir)
-    assert(ugerConfig.scriptDir === Locations.ugerScriptDir)
-    assert(ugerConfig.maxNumJobs === 44)
-    assert(ugerConfig.defaultCores === Cpus(42))
-    assert(ugerConfig.defaultMemoryPerCore=== Memory.inGb(9))
-    assert(ugerConfig.defaultMaxRunTime === CpuTime.inHours(11))
-    assert(ugerConfig.extraPathDir === path("/blah/baz"))
-    assert(ugerConfig.condaEnvName === "fooEnv")
-    assert(ugerConfig.staticJobSubmissionParams === "foo bar baz")
+    assert(config.workDir === Locations.ugerDir)
+    assert(config.scriptDir === Locations.ugerScriptDir)
+    assert(config.maxNumJobs === 44)
+    assert(config.defaultCores === Cpus(42))
+    assert(config.defaultMemoryPerCore=== Memory.inGb(9))
+    assert(config.defaultMaxRunTime === CpuTime.inHours(11))
+    assert(config.extraPathDir === path("/blah/baz"))
+    assert(config.condaEnvName === "fooEnv")
+    assert(config.staticJobSubmissionParams === "foo bar baz")
+    assert(config.maxQacctRetries === 123)
   }
   
   test("Parsing a UgerConfig with optional values omitted should work") {
@@ -68,16 +71,17 @@ final class UgerConfigTest extends FunSuite {
       }
       """)
       
-    val ugerConfig = UgerConfig.fromConfig(valid).get
+    val config = UgerConfig.fromConfig(valid).get
     
-    assert(ugerConfig.workDir === Locations.ugerDir)
-    assert(ugerConfig.scriptDir === Locations.ugerScriptDir)
-    assert(ugerConfig.maxNumJobs === UgerDefaults.maxConcurrentJobs)
-    assert(ugerConfig.defaultCores === UgerDefaults.cores)
-    assert(ugerConfig.defaultMemoryPerCore === UgerDefaults.memoryPerCore)
-    assert(ugerConfig.defaultMaxRunTime === UgerDefaults.maxRunTime)
-    assert(ugerConfig.extraPathDir === UgerDefaults.extraPathDir)
-    assert(ugerConfig.condaEnvName === UgerDefaults.condaEnvName)
-    assert(ugerConfig.staticJobSubmissionParams === UgerDefaults.staticJobSubmissionParams)
+    assert(config.workDir === Locations.ugerDir)
+    assert(config.scriptDir === Locations.ugerScriptDir)
+    assert(config.maxNumJobs === UgerDefaults.maxConcurrentJobs)
+    assert(config.defaultCores === UgerDefaults.cores)
+    assert(config.defaultMemoryPerCore === UgerDefaults.memoryPerCore)
+    assert(config.defaultMaxRunTime === UgerDefaults.maxRunTime)
+    assert(config.extraPathDir === UgerDefaults.extraPathDir)
+    assert(config.condaEnvName === UgerDefaults.condaEnvName)
+    assert(config.staticJobSubmissionParams === UgerDefaults.staticJobSubmissionParams)
+    assert(config.maxQacctRetries === UgerDefaults.maxQacctRetries)
   }
 }

--- a/src/test/scala/loamstream/drm/uger/MockQacctAccountingClient.scala
+++ b/src/test/scala/loamstream/drm/uger/MockQacctAccountingClient.scala
@@ -3,36 +3,47 @@ package loamstream.drm.uger
 import loamstream.drm.AccountingClient
 import loamstream.drm.Queue
 import loamstream.util.ValueBox
+import loamstream.conf.UgerConfig
+import scala.util.Try
 
 /**
  * @author clint
  * Mar 15, 2017
  */
-final class MockQacctAccountingClient(delegateFn: String => Seq[String]) extends AccountingClient {
-  val timesGetQacctOutputForInvoked: ValueBox[Int] = ValueBox(0)
+final class MockQacctAccountingClient(
+    delegateFn: String => Seq[String],
+    ugerConfig: UgerConfig = UgerConfig()) extends AccountingClient {
+  
+  private val timesGetQacctOutputForInvokedBox: ValueBox[Int] = ValueBox(0)
 
-  val timesGetExecutionNodeInvoked: ValueBox[Int] = ValueBox(0)
+  private val timesGetExecutionNodeInvokedBox: ValueBox[Int] = ValueBox(0)
 
-  val timesGetQueueInvoked: ValueBox[Int] = ValueBox(0)
+  private val timesGetQueueInvokedBox: ValueBox[Int] = ValueBox(0)
+  
+  def timesGetQacctOutputForInvoked: Int = timesGetQacctOutputForInvokedBox()
+
+  def timesGetExecutionNodeInvoked: Int = timesGetExecutionNodeInvokedBox()
+
+  def timesGetQueueInvoked: Int = timesGetQueueInvokedBox()
 
   private val actualDelegate = {
     val wrappedDelegateFn: String => Seq[String] = { jobId =>
-      timesGetQacctOutputForInvoked.mutate(_ + 1)
+      timesGetQacctOutputForInvokedBox.mutate(_ + 1)
 
       delegateFn(jobId)
     }
 
-    new QacctAccountingClient(wrappedDelegateFn)
+    new QacctAccountingClient(ugerConfig, wrappedDelegateFn)
   }
 
   override def getExecutionNode(jobId: String): Option[String] = {
-    timesGetExecutionNodeInvoked.mutate(_ + 1)
+    timesGetExecutionNodeInvokedBox.mutate(_ + 1)
 
     actualDelegate.getExecutionNode(jobId)
   }
 
   override def getQueue(jobId: String): Option[Queue] = {
-    timesGetQueueInvoked.mutate(_ + 1)
+    timesGetQueueInvokedBox.mutate(_ + 1)
 
     actualDelegate.getQueue(jobId)
   }

--- a/src/test/scala/loamstream/drm/uger/MockQacctAccountingClient.scala
+++ b/src/test/scala/loamstream/drm/uger/MockQacctAccountingClient.scala
@@ -5,6 +5,7 @@ import loamstream.drm.Queue
 import loamstream.util.ValueBox
 import loamstream.conf.UgerConfig
 import scala.util.Try
+import scala.concurrent.duration.Duration
 
 /**
  * @author clint
@@ -12,7 +13,9 @@ import scala.util.Try
  */
 final class MockQacctAccountingClient(
     delegateFn: String => Seq[String],
-    ugerConfig: UgerConfig = UgerConfig()) extends AccountingClient {
+    ugerConfig: UgerConfig = UgerConfig(),
+    delayStart: Duration = QacctAccountingClient.defaultDelayStart,
+    delayCap: Duration = QacctAccountingClient.defaultDelayCap) extends AccountingClient {
   
   private val timesGetQacctOutputForInvokedBox: ValueBox[Int] = ValueBox(0)
 
@@ -33,7 +36,7 @@ final class MockQacctAccountingClient(
       delegateFn(jobId)
     }
 
-    new QacctAccountingClient(ugerConfig, wrappedDelegateFn)
+    new QacctAccountingClient(ugerConfig, wrappedDelegateFn, delayStart, delayCap)
   }
 
   override def getExecutionNode(jobId: String): Option[String] = {

--- a/src/test/scala/loamstream/drm/uger/QacctAccountingClientTest.scala
+++ b/src/test/scala/loamstream/drm/uger/QacctAccountingClientTest.scala
@@ -3,6 +3,7 @@ package loamstream.drm.uger
 import org.scalatest.FunSuite
 
 import loamstream.drm.Queue
+import loamstream.conf.UgerConfig
 
 /**
  * @author clint
@@ -12,6 +13,91 @@ final class QacctAccountingClientTest extends FunSuite {
 
   import QacctTestHelpers.actualQacctOutput
 
+  test("retries - never works") {
+    val maxRuns = 2
+    
+    val ugerConfig = UgerConfig(maxQacctRetries = maxRuns - 1)
+    
+    val mockClient = new MockQacctAccountingClient(_ => throw new Exception, ugerConfig)
+    
+    val jobId = "abc123"
+    
+    assert(mockClient.timesGetQacctOutputForInvoked === 0)
+    assert(mockClient.timesGetExecutionNodeInvoked === 0)
+    assert(mockClient.timesGetQueueInvoked === 0)
+    
+    assert(mockClient.getExecutionNode(jobId).isEmpty)
+    
+    //Should have retried once
+    assert(mockClient.timesGetQacctOutputForInvoked === 2)
+    assert(mockClient.timesGetExecutionNodeInvoked === 1)
+    assert(mockClient.timesGetQueueInvoked === 0)
+    
+    assert(mockClient.getExecutionNode(jobId).isEmpty)
+    
+    //should have memoized results, and not retried any more
+    assert(mockClient.timesGetQacctOutputForInvoked === 2)
+    assert(mockClient.timesGetExecutionNodeInvoked === 2)
+    assert(mockClient.timesGetQueueInvoked === 0)
+    
+    assert(mockClient.getQueue(jobId).isEmpty)
+    
+    //should have memoized results, and not retried any more
+    assert(mockClient.timesGetQacctOutputForInvoked === 2)
+    assert(mockClient.timesGetExecutionNodeInvoked === 2)
+    assert(mockClient.timesGetQueueInvoked === 1)
+  }
+  
+  test("retries - works after 2 failures") {
+    val maxRuns = 5
+    
+    val ugerConfig = UgerConfig(maxQacctRetries = maxRuns - 1)
+    
+    val expectedNode: String = "uger-c052.broadinstitute.org"
+    val expectedQueue: Queue = Queue("broad")
+    
+    var timesQacctInvoked = 0
+    
+    def invokeQacct(jobId: String): Seq[String] = {
+      timesQacctInvoked += 1
+      
+      if(timesQacctInvoked < 3) {
+        throw new Exception
+      } else {
+        actualQacctOutput(Some(expectedQueue), Some(expectedNode))
+      }
+    }
+    
+    val mockClient = new MockQacctAccountingClient(invokeQacct, ugerConfig)
+    
+    val jobId = "abc123"
+    
+    assert(mockClient.timesGetQacctOutputForInvoked === 0)
+    assert(mockClient.timesGetExecutionNodeInvoked === 0)
+    assert(mockClient.timesGetQueueInvoked === 0)
+    
+    assert(mockClient.getExecutionNode(jobId) === Some(expectedNode))
+    
+    //Should have retried twice
+    assert(mockClient.timesGetQacctOutputForInvoked === 3)
+    assert(mockClient.timesGetExecutionNodeInvoked === 1)
+    assert(mockClient.timesGetQueueInvoked === 0)
+    
+    assert(mockClient.getExecutionNode(jobId) === Some(expectedNode))
+    
+    //should have memoized results, and not retried any more
+    assert(mockClient.timesGetQacctOutputForInvoked === 3)
+    assert(mockClient.timesGetExecutionNodeInvoked === 2)
+    assert(mockClient.timesGetQueueInvoked === 0)
+    
+    assert(mockClient.getQueue(jobId) === Some(expectedQueue))
+    
+    //should have memoized results, and not retried any more
+    assert(mockClient.timesGetQacctOutputForInvoked === 3)
+    assert(mockClient.timesGetExecutionNodeInvoked === 2)
+    assert(mockClient.timesGetQueueInvoked === 1)
+  }
+  
   test("QacctUgerClient.getExecutionNode") {
     val expectedNode: String = "uger-c052.broadinstitute.org"
     val expectedQueue: Queue = Queue("broad")
@@ -23,16 +109,16 @@ final class QacctAccountingClientTest extends FunSuite {
 
     assert(actualNode === Some(expectedNode))
 
-    assert(mockClient.timesGetExecutionNodeInvoked() === 1)
-    assert(mockClient.timesGetQacctOutputForInvoked() === 1)
-    assert(mockClient.timesGetQueueInvoked() === 0)
+    assert(mockClient.timesGetExecutionNodeInvoked === 1)
+    assert(mockClient.timesGetQacctOutputForInvoked === 1)
+    assert(mockClient.timesGetQueueInvoked === 0)
 
     assert(mockClient.getExecutionNode(jobId) === Some(expectedNode))
 
-    assert(mockClient.timesGetExecutionNodeInvoked() === 2)
+    assert(mockClient.timesGetExecutionNodeInvoked === 2)
     //Invocations of qacct should be memoized
-    assert(mockClient.timesGetQacctOutputForInvoked() === 1)
-    assert(mockClient.timesGetQueueInvoked() === 0)
+    assert(mockClient.timesGetQacctOutputForInvoked === 1)
+    assert(mockClient.timesGetQueueInvoked === 0)
   }
 
   test("QacctUgerClient.getQueue") {
@@ -44,16 +130,16 @@ final class QacctAccountingClientTest extends FunSuite {
 
     assert(mockClient.getQueue(jobId) === Some(expectedQueue))
 
-    assert(mockClient.timesGetExecutionNodeInvoked() === 0)
-    assert(mockClient.timesGetQacctOutputForInvoked() === 1)
-    assert(mockClient.timesGetQueueInvoked() === 1)
+    assert(mockClient.timesGetExecutionNodeInvoked === 0)
+    assert(mockClient.timesGetQacctOutputForInvoked === 1)
+    assert(mockClient.timesGetQueueInvoked === 1)
 
     assert(mockClient.getQueue(jobId) === Some(expectedQueue))
 
-    assert(mockClient.timesGetExecutionNodeInvoked() === 0)
+    assert(mockClient.timesGetExecutionNodeInvoked === 0)
     //Invocations of qacct should be memoized
-    assert(mockClient.timesGetQacctOutputForInvoked() === 1)
-    assert(mockClient.timesGetQueueInvoked() === 2)
+    assert(mockClient.timesGetQacctOutputForInvoked === 1)
+    assert(mockClient.timesGetQueueInvoked === 2)
   }
 
   test("QacctUgerClient.getExecutionNode - no node to find") {
@@ -63,16 +149,16 @@ final class QacctAccountingClientTest extends FunSuite {
 
     assert(mockClient.getExecutionNode(jobId) === None)
 
-    assert(mockClient.timesGetExecutionNodeInvoked() === 1)
-    assert(mockClient.timesGetQacctOutputForInvoked() === 1)
-    assert(mockClient.timesGetQueueInvoked() === 0)
+    assert(mockClient.timesGetExecutionNodeInvoked === 1)
+    assert(mockClient.timesGetQacctOutputForInvoked === 1)
+    assert(mockClient.timesGetQueueInvoked === 0)
 
     assert(mockClient.getExecutionNode(jobId) === None)
 
-    assert(mockClient.timesGetExecutionNodeInvoked() === 2)
+    assert(mockClient.timesGetExecutionNodeInvoked === 2)
     //Invocations of qacct should be memoized
-    assert(mockClient.timesGetQacctOutputForInvoked() === 1)
-    assert(mockClient.timesGetQueueInvoked() === 0)
+    assert(mockClient.timesGetQacctOutputForInvoked === 1)
+    assert(mockClient.timesGetQueueInvoked === 0)
   }
 
   test("QacctUgerClient.getQueue - no queue to find") {
@@ -82,16 +168,16 @@ final class QacctAccountingClientTest extends FunSuite {
 
     assert(mockClient.getQueue(jobId) === None)
 
-    assert(mockClient.timesGetExecutionNodeInvoked() === 0)
-    assert(mockClient.timesGetQacctOutputForInvoked() === 1)
-    assert(mockClient.timesGetQueueInvoked() === 1)
+    assert(mockClient.timesGetExecutionNodeInvoked === 0)
+    assert(mockClient.timesGetQacctOutputForInvoked === 1)
+    assert(mockClient.timesGetQueueInvoked === 1)
 
     assert(mockClient.getQueue(jobId) === None)
 
-    assert(mockClient.timesGetExecutionNodeInvoked() === 0)
+    assert(mockClient.timesGetExecutionNodeInvoked === 0)
     //Invocations of qacct should be memoized
-    assert(mockClient.timesGetQacctOutputForInvoked() === 1)
-    assert(mockClient.timesGetQueueInvoked() === 2)
+    assert(mockClient.timesGetQacctOutputForInvoked === 1)
+    assert(mockClient.timesGetQueueInvoked === 2)
   }
 
   test("QacctUgerClient.getQueue,getExecutionNode - neither present") {
@@ -102,17 +188,17 @@ final class QacctAccountingClientTest extends FunSuite {
     assert(mockClient.getQueue(jobId) === None)
     assert(mockClient.getExecutionNode(jobId) === None)
 
-    assert(mockClient.timesGetExecutionNodeInvoked() === 1)
-    assert(mockClient.timesGetQacctOutputForInvoked() === 1)
-    assert(mockClient.timesGetQueueInvoked() === 1)
+    assert(mockClient.timesGetExecutionNodeInvoked === 1)
+    assert(mockClient.timesGetQacctOutputForInvoked === 1)
+    assert(mockClient.timesGetQueueInvoked === 1)
 
     assert(mockClient.getQueue(jobId) === None)
     assert(mockClient.getExecutionNode(jobId) === None)
 
-    assert(mockClient.timesGetExecutionNodeInvoked() === 2)
+    assert(mockClient.timesGetExecutionNodeInvoked === 2)
     //Invocations of qacct should be memoized
-    assert(mockClient.timesGetQacctOutputForInvoked() === 1)
-    assert(mockClient.timesGetQueueInvoked() === 2)
+    assert(mockClient.timesGetQacctOutputForInvoked === 1)
+    assert(mockClient.timesGetQueueInvoked === 2)
   }
 
   test("QacctUgerClient.getQueue,getExecutionNode - junk output") {

--- a/src/test/scala/loamstream/drm/uger/QacctAccountingClientTest.scala
+++ b/src/test/scala/loamstream/drm/uger/QacctAccountingClientTest.scala
@@ -13,6 +13,28 @@ final class QacctAccountingClientTest extends FunSuite {
 
   import QacctTestHelpers.actualQacctOutput
 
+  test("delaySequence") {
+    val delays = QacctAccountingClient.delaySequence
+    
+    val actual = delays.take(10).toIndexedSeq
+    
+    import scala.concurrent.duration._
+    
+    val expected = Seq(
+        0.5.seconds, 
+        1.second, 
+        2.seconds, 
+        4.seconds, 
+        8.seconds, 
+        16.seconds,
+        30.seconds,
+        30.seconds,
+        30.seconds,
+        30.seconds)
+        
+    assert(actual === expected)
+  }
+  
   test("retries - never works") {
     val maxRuns = 2
     

--- a/src/test/scala/loamstream/drm/uger/UgerResourceUsageExtractorTest.scala
+++ b/src/test/scala/loamstream/drm/uger/UgerResourceUsageExtractorTest.scala
@@ -51,8 +51,8 @@ final class UgerResourceUsageExtractorTest extends FunSuite {
     //Should fail; incomplete info from JobInfo
     assert(toResources(jobInfo).isFailure)
     
-    assert(mockUgerClient.timesGetExecutionNodeInvoked() == 0)
-    assert(mockUgerClient.timesGetQueueInvoked() == 0)
+    assert(mockUgerClient.timesGetExecutionNodeInvoked == 0)
+    assert(mockUgerClient.timesGetQueueInvoked == 0)
   }
   
   test("fromUgerMap - real-world data") {


### PR DESCRIPTION
- Retry `qacct` if it fails, up to `loamstream.uger.maxQacctRetries` (from `loamstream.conf`) times.
- Default is to retry `qacct` at most 9 times, or in other words, run `qacct` a maximum of 10 times.
- Wait longer and longer in between subsequent failures, starting at 0.5s and doubling each time, up to 30s.
