### PR TITLE
Don't wait for all the jobs in a chunk to finish before running successors of any chunk members

### DIFF
--- a/src/main/scala/loamstream/googlecloud/GoogleCloudChunkRunner.scala
+++ b/src/main/scala/loamstream/googlecloud/GoogleCloudChunkRunner.scala
@@ -101,7 +101,7 @@ final case class GoogleCloudChunkRunner(
     //on the same cluster simultaneously
     import loamstream.util.Observables.Implicits._
 
-    val futureResult = delegate.run(Set(job), shouldRestart).map(addCluster(googleConfig.clusterId)).firstAsFuture
+    val futureResult = delegate.run(Set(job), shouldRestart).map(addCluster(googleConfig.clusterId)).lastAsFuture
     
     //TODO: add some timeout
     Await.result(futureResult, Duration.Inf)

--- a/src/main/scala/loamstream/model/execute/AsyncLocalChunkRunner.scala
+++ b/src/main/scala/loamstream/model/execute/AsyncLocalChunkRunner.scala
@@ -45,6 +45,8 @@ final case class AsyncLocalChunkRunner(
         
       val z: Map[LJob, RunData] = Map.empty
       
+      //NB: Note the use of scan() here.  It ensures that an item is emitted for a job as soon as that job finishes,     
+      //instead of only once when all the jobs in a chunk finish.
       Observables.merge(executionObservables).scan(z) { (acc, runData) => acc + (runData.job -> runData) }
     }
   }

--- a/src/main/scala/loamstream/model/execute/AsyncLocalChunkRunner.scala
+++ b/src/main/scala/loamstream/model/execute/AsyncLocalChunkRunner.scala
@@ -45,7 +45,7 @@ final case class AsyncLocalChunkRunner(
         
       val z: Map[LJob, RunData] = Map.empty
       
-      //NB: Note the use of scan() here.  It ensures that an item is emitted for a job as soon as that job finishes,     
+      //NB: Note the use of scan() here.  It ensures that an item is emitted for a job as soon as that job finishes,
       //instead of only once when all the jobs in a chunk finish.
       Observables.merge(executionObservables).scan(z) { (acc, runData) => acc + (runData.job -> runData) }
     }

--- a/src/main/scala/loamstream/model/execute/AsyncLocalChunkRunner.scala
+++ b/src/main/scala/loamstream/model/execute/AsyncLocalChunkRunner.scala
@@ -43,11 +43,9 @@ final case class AsyncLocalChunkRunner(
 
       val executionObservables: Seq[Observable[RunData]] = jobs.toSeq.map(exec)
         
-      val sequenceObservable: Observable[Seq[RunData]] = Observables.sequence(executionObservables)
+      val z: Map[LJob, RunData] = Map.empty
       
-      import Traversables.Implicits._
-      
-      sequenceObservable.foldLeft(Map.empty[LJob, RunData]) { (acc, runDatas) => acc ++ runDatas.mapBy(_.job) }
+      Observables.merge(executionObservables).scan(z) { (acc, runData) => acc + (runData.job -> runData) }
     }
   }
 }

--- a/src/main/scala/loamstream/model/execute/CompositeChunkRunner.scala
+++ b/src/main/scala/loamstream/model/execute/CompositeChunkRunner.scala
@@ -31,7 +31,11 @@ final case class CompositeChunkRunner(components: Seq[ChunkRunner]) extends Chun
       runner.run(jobsForRunner, shouldRestart)
     }
     
-    Observables.reduceMaps(resultObservables)
+    val z: Map[LJob, RunData] = Map.empty
+    
+    //NB: Note the use of scan() here.  It ensures that an item is emitted for a job as soon as that job finishes,     
+    //instead of only once when all the jobs in a chunk finish.
+    Observables.merge(resultObservables).scan(z)(_ ++ _).distinct
   }
   
   override def stop(): Unit = {

--- a/src/main/scala/loamstream/model/execute/RxExecuter.scala
+++ b/src/main/scala/loamstream/model/execute/RxExecuter.scala
@@ -112,6 +112,9 @@ final case class RxExecuter(
   //NB: shouldRestart() mostly factored out to the companion object for simpler testing
   private def shouldRestart(job: LJob): Boolean = RxExecuter.shouldRestart(job, maxRunsPerJob)
   
+  //Produce Optional LJob -> Execution tuples.  We need to be able to produce just one (empty) item,
+  //instead of just returning Observable.empty, so that code chained onto this method's result with
+  //flatMap will run.
   private def runJobs(jobsToRun: Iterable[LJob]): Observable[Option[(LJob, Execution)]] = {
     logJobsToBeRun(jobsToRun)
     

--- a/src/main/scala/loamstream/util/Observables.scala
+++ b/src/main/scala/loamstream/util/Observables.scala
@@ -68,35 +68,6 @@ object Observables extends Loggable {
   }
   
   /**
-   * Folds a bunch of Observables producing Maps[A,B] into one Map[A,B].  Individial maps are combined with ++.
-   * 
-   * @param os: a Traversable collection of Observables producing Map[A,B]s.
-   * @return: An Observables producing *a single* Map[A,B], the result of merging all the maps from all the 
-   * Observables.  This is done by successively applying ++ on each map and an accumulator. This result Observbable
-   * will emit *only one* map. 
-   */
-  def reduceMaps[A,B](os: Traversable[Observable[Map[A,B]]]): Observable[Map[A,B]] = {
-    def empty = Map.empty[A,B]
-    
-    def reduce(o: Observable[Map[A,B]]): Observable[Map[A,B]] = o.orElse(empty).reduce(_ ++ _).last
-    
-    //Consume each Observable in os, producing a new bunch of Observable[Map[A,B]]s, where each of the
-    //the new Observable only emits one value - the result of merging/reducing all the maps it emits. 
-    val reducedOs = os.map(reduce)
-    
-    val z: Observable[Map[A,B]] = Observable.just(Map.empty)
-    
-    val mergedMaps = reducedOs.foldLeft(z) { (accObs, o) =>
-      for {
-        acc <- accObs
-        map <- o
-      } yield acc ++ map
-    }
-    
-    mergedMaps.orElse(empty).last
-  }
-  
-  /**
    * Expose the method rx.Observables.merge in a Scala-friendly way.  Given
    * 
    * val os: Iterable[Observable[A]] = ...

--- a/src/test/scala/loamstream/googlecloud/GoogleCloudChunkRunnerTest.scala
+++ b/src/test/scala/loamstream/googlecloud/GoogleCloudChunkRunnerTest.scala
@@ -21,6 +21,7 @@ import loamstream.model.execute.Environment
 import loamstream.conf.ExecutionConfig
 import loamstream.model.jobs.OutputStreams
 import loamstream.model.jobs.RunData
+import loamstream.util.Maps
 
 
 /**
@@ -130,7 +131,9 @@ final class GoogleCloudChunkRunnerTest extends FunSuite with ProvidesEnvAndResou
       
       val runDataObs = actualGoogleRunner.runJobsSequentially(Set(job1, job2, job3), neverRestart)
       
-      val runDatas = waitFor(runDataObs.lastAsFuture)
+      val z: Map[LJob, RunData] = Map.empty 
+      
+      val runDatas = waitFor(runDataObs.foldLeft(z)(_ ++ _).lastAsFuture)
       
       assert(runDatas(job1) === job1.toReturn)
       assert(runDatas(job2) === job2.toReturn)
@@ -298,7 +301,11 @@ final class GoogleCloudChunkRunnerTest extends FunSuite with ProvidesEnvAndResou
       assert(client.startClusterInvocations() === 0)
       assert(client.deleteClusterInvocations() === 0)
       
-      val jobRuns = waitFor(googleRunner.run(Set(job1, job2, job3), neverRestart).lastAsFuture)
+      val z: Map[LJob, RunData] = Map.empty
+      
+      val runDataObs = googleRunner.run(Set(job1, job2, job3), neverRestart)
+      
+      val jobRuns = waitFor(runDataObs.foldLeft(z)(_ ++ _).lastAsFuture)
       
       assert(client.clusterRunning() === true)
       assert(client.startClusterInvocations() === 1)

--- a/src/test/scala/loamstream/model/execute/CompositeChunkRunnerTest.scala
+++ b/src/test/scala/loamstream/model/execute/CompositeChunkRunnerTest.scala
@@ -70,7 +70,7 @@ final class CompositeChunkRunnerTest extends FunSuite {
     
     import Observables.Implicits._
     
-    val futureResults = runner.run(Set(job1, job2), neverRestart).firstAsFuture
+    val futureResults = runner.run(Set(job1, job2), neverRestart).lastAsFuture
     
     val expected = Map(job1 -> JobStatus.Succeeded, job2 -> JobStatus.Failed)
     

--- a/src/test/scala/loamstream/model/execute/ExecutionResumptionTest.scala
+++ b/src/test/scala/loamstream/model/execute/ExecutionResumptionTest.scala
@@ -178,7 +178,7 @@ final class ExecutionResumptionTest extends FunSuite with ProvidesSlickLoamDao w
 
       val expectedNumResults = if (runningEverything) 3 else expectations.count(_.isSuccess)
 
-      assert(jobResults.size == expectedNumResults, s"Got ${jobResults.size} results but expected ${expectedNumResults} given expected statuses: ${expectedStatuses}")
+      assert(jobResults.size == expectedNumResults)
 
       assert(jobResults.values.forall(_.isSuccess))
     }

--- a/src/test/scala/loamstream/model/execute/ExecutionResumptionTest.scala
+++ b/src/test/scala/loamstream/model/execute/ExecutionResumptionTest.scala
@@ -178,7 +178,7 @@ final class ExecutionResumptionTest extends FunSuite with ProvidesSlickLoamDao w
 
       val expectedNumResults = if (runningEverything) 3 else expectations.count(_.isSuccess)
 
-      assert(jobResults.size == expectedNumResults)
+      assert(jobResults.size == expectedNumResults, s"Got ${jobResults.size} results but expected ${expectedNumResults} given expected statuses: ${expectedStatuses}")
 
       assert(jobResults.values.forall(_.isSuccess))
     }

--- a/src/test/scala/loamstream/util/ObservablesTest.scala
+++ b/src/test/scala/loamstream/util/ObservablesTest.scala
@@ -144,44 +144,6 @@ final class ObservablesTest extends FunSuite {
     }
   }
   
-  private def doReduceMapsTest(os: Seq[Observable[Map[String,Int]]], expected: Map[String, Int]): Unit = {
-    import Observables.reduceMaps
-    
-    waitFor(reduceMaps(os).to[Seq].firstAsFuture) === Seq(expected)
-  }
-  
-  test("reduceMaps - empty input") {
-    doReduceMapsTest(Seq.empty, Map.empty)
-  }
-    
-  test("reduceMaps - empty inputs (plural)") {
-    doReduceMapsTest(Seq(Observable.empty, Observable.empty, Observable.empty), Map.empty)
-  }
-
-  test("reduceMaps - non-empty input") {
-    val m0 = Map("a" -> 1, "b"-> 2)
-    val m1 = Map("c" -> 3)
-    val m2 = Map("d" -> 4, "e"-> 5)
-    val m3 = Map("f" -> 5)
-    val m4 = Map("g" -> 6, "h"-> 7)
-    
-    val o0 = Observable.just(m0)
-    val o1 = Observable.just(m1, m2)
-    val o2 = Observable.just(m3, m4)
-    
-    val expected = Map(
-        "a" -> 1, 
-        "b"-> 2,
-        "c" -> 3,
-        "d" -> 4, 
-        "e"-> 5,
-        "f" -> 5,
-        "g" -> 6, 
-        "h"-> 7)
-    
-    doReduceMapsTest(Seq(o0, o1, o2), expected)
-  }
-  
   test("merge - empty input") {
     import Observables.merge
     


### PR DESCRIPTION
Previously, LS ran jobs in chunks, and waited for all the jobs in the chunk to finish before running any jobs that follow on from any of the chunk members.  This means that for a chunk of N jobs, where N - 1 finish quickly, and 1 finishes slowly, the successors of the fast jobs wouldn't run until the slow job finished.  That produced correct results, but meant jobs potentially waited to run for longer than they needed to.

Jenkins-run unit tests passed; the integration tests are ongoing.  @rmkoesterer should also chime in to confirm that this works.