### PR TITLE
Mark jobs that are cancelled due to missing inputs at execution-time as CouldNotRun instead of FailedPermanently

### DIFF
--- a/src/main/scala/loamstream/model/execute/RxExecuter.scala
+++ b/src/main/scala/loamstream/model/execute/RxExecuter.scala
@@ -131,13 +131,13 @@ final case class RxExecuter(
   }
   
   private def cancelJobs(jobsToCancel: Iterable[LJob]): Map[LJob, Execution] = {
-    import JobStatus.FailedPermanently
+    import JobStatus.CouldNotStart
     
-    jobsToCancel.foreach(_.transitionTo(FailedPermanently))
+    jobsToCancel.foreach(_.transitionTo(CouldNotStart))
     
     import loamstream.util.Traversables.Implicits._
     
-    jobsToCancel.mapTo(job => Execution.from(job, FailedPermanently))
+    jobsToCancel.mapTo(job => Execution.from(job, CouldNotStart))
   }
   
   private def handleSkippedJobs(skippedJobs: Iterable[LJob]): Unit = {

--- a/src/main/scala/loamstream/model/jobs/JobNode.scala
+++ b/src/main/scala/loamstream/model/jobs/JobNode.scala
@@ -128,7 +128,7 @@ trait JobNode extends Loggable {
         for {
           inputStatuses <- finalInputStatuses
           _ = trace(logMsg(s"deps finished with statuses: $inputStatuses"))
-          anyInputFailures = inputStatuses.exists(_.isFailure)
+          anyInputFailures = inputStatuses.exists(_.canStopExecution)
           runnable <- if(anyInputFailures) stopDueToDependencyFailure() else justUs
         } yield {
           runnable

--- a/src/main/scala/loamstream/model/jobs/JobStatus.scala
+++ b/src/main/scala/loamstream/model/jobs/JobStatus.scala
@@ -14,19 +14,21 @@ sealed trait JobStatus {
   
   def isTerminal: Boolean
 
-  def isFinished: Boolean = isSuccess || isFailure || isTerminal
+  final def isFinished: Boolean = isSuccess || isFailure || isTerminal
 
-  def notFinished: Boolean = !isFinished
+  final def notFinished: Boolean = !isFinished
   
-  def isSkipped: Boolean = this == JobStatus.Skipped
+  final def isSkipped: Boolean = this == JobStatus.Skipped
   
-  def isPermanentFailure: Boolean = this == JobStatus.FailedPermanently
+  final def isPermanentFailure: Boolean = this == JobStatus.FailedPermanently
 
-  def isCouldNotStart: Boolean = this == JobStatus.CouldNotStart
+  final def isCouldNotStart: Boolean = this == JobStatus.CouldNotStart
   
-  def isRunning: Boolean = this == JobStatus.Running
+  final def isRunning: Boolean = this == JobStatus.Running
   
-  def notRunning: Boolean = !isRunning
+  final def notRunning: Boolean = !isRunning
+  
+  final def canStopExecution: Boolean = isFailure || isCouldNotStart
 }
 
 object JobStatus extends Loggable {

--- a/src/test/scala/loamstream/model/execute/RxExecuterTest.scala
+++ b/src/test/scala/loamstream/model/execute/RxExecuterTest.scala
@@ -129,10 +129,11 @@ final class RxExecuterTest extends FunSuite {
       assert(job3.executionCount === 0)
   
       assert(result(job1).isSuccess)
-      assert(result(job2).isFailure)
+      assert(result(job2).isFailure === false)
+      assert(result(job2).isSuccess === false)
       assert(result.get(job3) === None)
       
-      assert(result(job2).status === JobStatus.FailedPermanently)
+      assert(result(job2).status === JobStatus.CouldNotStart)
       
       assert(result(job2).result === None)
       

--- a/src/test/scala/loamstream/model/jobs/JobStatusTest.scala
+++ b/src/test/scala/loamstream/model/jobs/JobStatusTest.scala
@@ -9,6 +9,21 @@ import org.scalatest.FunSuite
 final class JobStatusTest extends FunSuite {
   import JobStatus._
   
+  test("canStopExecution") {
+    assert(Succeeded.canStopExecution === false)
+    assert(Skipped.canStopExecution === false)
+    assert(Failed.canStopExecution === true)
+    assert(FailedWithException.canStopExecution === true)
+    assert(NotStarted.canStopExecution === false)
+    assert(Submitted.canStopExecution === false)
+    assert(Running.canStopExecution === false)
+    assert(Terminated.canStopExecution === true)
+    assert(Unknown.canStopExecution === false)
+    assert(CouldNotStart.canStopExecution === true)
+    assert(FailedPermanently.canStopExecution === true)
+    assert(WaitingForOutputs.canStopExecution === false)
+  }
+  
   test("isPermanentFailure") {
     assert(Succeeded.isPermanentFailure === false)
     assert(Skipped.isPermanentFailure === false)


### PR DESCRIPTION
This is a minor change that's independent of the other open PRs.  It doesn't change how pipelines run, but it does make for nicer reporting at the end of runs by distinguishing between all the jobs that LS chose not to run and those that ran and then died.