### PR TITLE
Respect --disable-hashing, hash files only when needed and cache the results

### DIFF
--- a/src/it/resources/hail-at-google/loamstream.conf
+++ b/src/it/resources/hail-at-google/loamstream.conf
@@ -16,7 +16,7 @@ loamstream {
     defaultClusterConfig {
       masterMachineType = "n1-standard-1"
       workerMachineType = "n1-standard-1"
-      numWorkers = 2
+      numWorkers = 4
       numPreemptibleWorkers = 0
     }
     hail {

--- a/src/main/scala/loamstream/compiler/LoamPredef.scala
+++ b/src/main/scala/loamstream/compiler/LoamPredef.scala
@@ -143,7 +143,9 @@ object LoamPredef extends Loggable {
   }
   
   def google[A](expr: => A)(implicit scriptContext: LoamScriptContext): A = {
-    googleWith(ClusterConfig.default)(expr)(scriptContext)
+    val defaultClusterConfig = scriptContext.googleConfig.defaultClusterConfig
+    
+    googleWith(defaultClusterConfig)(expr)(scriptContext)
   }
 
   def googleWith[A](clusterConfig: ClusterConfig)(expr: => A)(implicit scriptContext: LoamScriptContext): A = {

--- a/src/main/scala/loamstream/db/slick/OutputRow.scala
+++ b/src/main/scala/loamstream/db/slick/OutputRow.scala
@@ -58,5 +58,5 @@ final case class OutputRow( loc: String,
 
   def withExecutionId(newExecutionId: Int): OutputRow = copy(executionId = Some(newExecutionId))
 
-  def toOutputRecord: StoreRecord = StoreRecord(loc, hash, hashType, lastModified.map(_.toInstant))
+  def toOutputRecord: StoreRecord = StoreRecord(loc, () => hash, () => hashType, lastModified.map(_.toInstant))
 }

--- a/src/main/scala/loamstream/model/execute/DbBackedJobFilter.scala
+++ b/src/main/scala/loamstream/model/execute/DbBackedJobFilter.scala
@@ -36,7 +36,7 @@ final class DbBackedJobFilter(
   // for a given OutputRecord should help
   private[execute] def needsToBeRun(jobStr: String, rec: StoreRecord): Boolean = {
     val msg = s"Job $jobStr will be run because its output"
-
+    
     val considerHashes = outputHashingStrategy.shouldHash
     
     val missingFromDisk = rec.isMissing

--- a/src/main/scala/loamstream/model/jobs/DataHandle.scala
+++ b/src/main/scala/loamstream/model/jobs/DataHandle.scala
@@ -45,7 +45,7 @@ object DataHandle {
     
     override def isPresent: Boolean = Files.exists(path)
 
-    override def hash: Option[Hash] = if (isPresent) Option(Hashes.sha1(path)) else None
+    override lazy val hash: Option[Hash] = if (isPresent) Option(Hashes.sha1(path)) else None
 
     override def lastModified: Option[Instant] = {
       if (isPresent) Option(Paths.lastModifiedTime(path)) else None
@@ -57,8 +57,8 @@ object DataHandle {
       StoreRecord( 
           loc = location,
           isPresent = isPresent,
-          hash = hashToString(hash),
-          hashType = hashTypeToString(hashType),
+          makeHash = () => hashToString(hash),
+          makeHashType = () => hashTypeToString(hashType),
           lastModified = lastModified)
     }
 
@@ -72,7 +72,7 @@ object DataHandle {
   final case class GcsUriHandle(uri: URI, client: Option[CloudStorageClient]) extends DataHandle {
     override def isPresent = client.exists(_.isPresent(uri))
 
-    override def hash: Option[Hash] = client.flatMap(_.hash(uri))
+    override lazy val hash: Option[Hash] = client.flatMap(_.hash(uri))
 
     override def lastModified: Option[Instant] = client.flatMap(_.lastModified(uri))
 
@@ -82,8 +82,8 @@ object DataHandle {
       StoreRecord( 
           loc = location,
           isPresent = isPresent,
-          hash = hashToString(hash),
-          hashType = hashTypeToString(hashType),
+          makeHash = () => hashToString(hash),
+          makeHashType = () => hashTypeToString(hashType),
           lastModified = lastModified)
     }
   }

--- a/src/main/scala/loamstream/model/jobs/StoreRecord.scala
+++ b/src/main/scala/loamstream/model/jobs/StoreRecord.scala
@@ -13,12 +13,38 @@ import loamstream.util.Paths
  * A container for job output attributes that are to be recorded and are not system-dependent
  * (e.g. in hash type or how resources are identified [URI/Path/etc])
  */
-final case class StoreRecord(loc: String,
-                              isPresent: Boolean,
-                              hash: Option[String],
-                              hashType: Option[String],
-                              lastModified: Option[Instant]) {
+final class StoreRecord private (
+    val loc: String,
+    val isPresent: Boolean,
+    private val makeHash: () => Option[String],
+    private val makeHashType: () => Option[String],
+    val lastModified: Option[Instant]) {
 
+  lazy val hash: Option[String] = makeHash()
+  lazy val hashType: Option[String] = makeHashType()
+  
+  def copy(
+      loc: String = this.loc,
+      isPresent: Boolean = this.isPresent,
+      lastModified: Option[Instant] = this.lastModified): StoreRecord = {
+    new StoreRecord(loc, isPresent, makeHash, makeHashType, lastModified)
+  }
+  
+  //NB: This will force the evaluation of hash and hashType!
+  override def equals(other: Any): Boolean = other match {
+    case that: StoreRecord => {
+      this.loc == that.loc &&
+      this.isPresent == that.isPresent &&
+      this.hash == that.hash &&
+      this.hashType == that.hashType &&
+      this.lastModified == that.lastModified
+    }
+    case _ => false
+  }
+  
+  //NB: This will force the evaluation of hash and hashType! 
+  override def hashCode: Int = List(loc, isPresent, hash, hashType, lastModified).hashCode
+  
   def isMissing: Boolean = !isPresent
 
   def hasDifferentModTimeThan(other: StoreRecord): Boolean = {
@@ -32,14 +58,16 @@ final case class StoreRecord(loc: String,
 
   def isHashed: Boolean = hash.isDefined
 
-  def hasDifferentHashThan(other: StoreRecord): Boolean = (
-    for {
+  def hasDifferentHashThan(other: StoreRecord): Boolean = {
+    (for {
       hashValue <- hash
       hashKind <- hashType
       otherHashValue <- other.hash
       otherHashKind <- other.hashType
-    } yield hashKind != otherHashKind || hashValue != otherHashValue
-    ).getOrElse(false)
+    } yield {
+      hashKind != otherHashKind || hashValue != otherHashValue
+    }).getOrElse(false)
+  }
 
   def withLastModified(t: Instant) = copy(lastModified = Option(t))
 
@@ -49,37 +77,46 @@ final case class StoreRecord(loc: String,
 }
 
 object StoreRecord {
+  def apply(loc: String,
+            isPresent: Boolean,
+            makeHash: () => Option[String],
+            makeHashType: () => Option[String],
+            lastModified: Option[Instant]): StoreRecord = {
+    new StoreRecord(loc, isPresent, makeHash, makeHashType, lastModified) 
+  }
+  
   def apply(loc: String): StoreRecord = StoreRecord(loc,
-                                                      isPresent = false,
-                                                      hash = None,
-                                                      hashType = None,
-                                                      lastModified = None)
+                                                    isPresent = false,
+                                                    makeHash = () => None,
+                                                    makeHashType = () => None,
+                                                    lastModified = None)
                                                       
   def apply(path: Path): StoreRecord = StoreRecord(Paths.normalize(path))
   
   def apply(uri: URI): StoreRecord = StoreRecord(uri.toString)
 
   def apply(loc: String,
-            hash: Option[String],
-            hashType: Option[String],
+            hash: () => Option[String],
+            hashType: () => Option[String],
             lastModified: Option[Instant]): StoreRecord = StoreRecord(loc,
-                                                                        isPresent = lastModified.isDefined,
-                                                                        hash = hash,
-                                                                        hashType = hashType,
-                                                                        lastModified = lastModified)
+                                                                      isPresent = lastModified.isDefined,
+                                                                      makeHash = hash,
+                                                                      makeHashType = hashType,
+                                                                      lastModified = lastModified)
 
   
 
   def apply(output: DataHandle): StoreRecord = output.lastModified match {
-    case lmOpt @ Some(_) => StoreRecord( loc = output.location,
-                                          isPresent = true,
-                                          hash = output.hash.map(_.valueAsBase64String),
-                                          hashType = output.hashType.map(_.algorithmName),
-                                          lastModified = lmOpt)
+    case lmOpt @ Some(_) => StoreRecord(loc = output.location,
+                                        isPresent = true,
+                                        makeHash = () => output.hash.map(_.valueAsBase64String),
+                                        makeHashType = () => output.hashType.map(_.algorithmName),
+                                        lastModified = lmOpt)
+                                        
     case _ => StoreRecord( loc = output.location,
                             isPresent = false,
-                            hash = None,
-                            hashType = None,
+                            makeHash = () => None,
+                            makeHashType = () => None,
                             lastModified = None)
   }
 }

--- a/src/test/scala/loamstream/compiler/LoamPredefTest.scala
+++ b/src/test/scala/loamstream/compiler/LoamPredefTest.scala
@@ -29,12 +29,52 @@ import loamstream.googlecloud.ClusterConfig
  * May 5, 2017
  */
 final class LoamPredefTest extends FunSuite {
-  test("google") {
+  test("google - defaults") {
+    
     implicit val scriptContext = newScriptContext
+    
+    assert(scriptContext.config.googleConfig.get.defaultClusterConfig === ClusterConfig.default)
     
     val settings = GoogleSettings(scriptContext.googleConfig.clusterId, ClusterConfig.default)
     
     doSettingsTest(scriptContext, LocalSettings, settings, LoamPredef.google)
+  }
+  
+  test("google - non-defaults") {
+    val baseConfig = TestHelpers.config
+    
+    val baseGoogleConfig = baseConfig.googleConfig.get
+    
+    val newClusterConfig = ClusterConfig.default.copy(numWorkers = 42)
+    
+    assert(newClusterConfig !== ClusterConfig.default)
+    
+    val loamConfig = {
+      baseConfig.copy(googleConfig = Some(baseGoogleConfig.copy(defaultClusterConfig = newClusterConfig)))
+    }
+    
+    assert(loamConfig !== baseConfig)
+    
+    implicit val scriptContext = new LoamScriptContext(LoamProjectContext.empty(loamConfig))
+    
+    val settings = GoogleSettings(scriptContext.googleConfig.clusterId, newClusterConfig)
+    
+    doSettingsTest(scriptContext, LocalSettings, settings, LoamPredef.google)
+  }
+  
+  test("googleWith") {
+    
+    val newClusterConfig = ClusterConfig.default.copy(numWorkers = 42)
+    
+    assert(newClusterConfig !== ClusterConfig.default)
+    
+    implicit val scriptContext = newScriptContext
+    
+    assert(scriptContext.config.googleConfig.get.defaultClusterConfig === ClusterConfig.default)
+    
+    val settings = GoogleSettings(scriptContext.googleConfig.clusterId, newClusterConfig)
+    
+    doSettingsTest(scriptContext, LocalSettings, settings, LoamPredef.googleWith(newClusterConfig))
   }
   
   test("local") {

--- a/src/test/scala/loamstream/db/slick/ProvidesSlickLoamDao.scala
+++ b/src/test/scala/loamstream/db/slick/ProvidesSlickLoamDao.scala
@@ -24,7 +24,11 @@ trait ProvidesSlickLoamDao {
   protected def cachedOutput(path: Path, hash: Hash, lastModified: Instant): StoreRecord = {
     val hashValue = hash.valueAsBase64String
 
-    StoreRecord(Paths.normalize(path), Option(hashValue), Option(hash.tpe.algorithmName), Option(lastModified))
+    StoreRecord(
+        Paths.normalize(path), 
+        () => Option(hashValue), 
+        () => Option(hash.tpe.algorithmName), 
+        Option(lastModified))
   }
 
   protected def cachedOutput(path: Path, hash: Hash): StoreRecord = {

--- a/src/test/scala/loamstream/model/execute/DbBackedJobFilterTest.scala
+++ b/src/test/scala/loamstream/model/execute/DbBackedJobFilterTest.scala
@@ -213,10 +213,10 @@ final class DbBackedJobFilterTest extends FunSuite with ProvidesSlickLoamDao wit
 
       // Record with different hash:  'hasDifferentHash' --> true
       //                              'needsToBeRun' --> true
-      val recWithDiffHash = StoreRecord( cachedOutput1.loc,
-                                          Option("bogus-hash"),
-                                          Option(Sha1.algorithmName),
-                                          cachedOutput1.lastModified)
+      val recWithDiffHash = StoreRecord(cachedOutput1.loc,
+                                        () => Option("bogus-hash"),
+                                        () => Option(Sha1.algorithmName),
+                                        cachedOutput1.lastModified)
                                           
       assert(filter.hasDifferentHash(recWithDiffHash))
       assert(filter.needsToBeRun(jobName, recWithDiffHash))
@@ -302,10 +302,10 @@ final class DbBackedJobFilterTest extends FunSuite with ProvidesSlickLoamDao wit
 
       // Record with different hash:  'hasDifferentHash' --> true
       //                              'needsToBeRun' --> true
-      val recWithDiffHash = StoreRecord( cachedOutput1.loc,
-                                          Option("bogus-hash"),
-                                          Option(Sha1.algorithmName),
-                                          cachedOutput1.lastModified)
+      val recWithDiffHash = StoreRecord(cachedOutput1.loc,
+                                        () => Option("bogus-hash"),
+                                        () => Option(Sha1.algorithmName),
+                                        cachedOutput1.lastModified)
       assert(filter.hasDifferentHash(recWithDiffHash))
       assert(filter.hasDifferentModTime(recWithDiffHash) === false)
       //since hashes aren't considered


### PR DESCRIPTION
- Make `DataHandle.{Path,GcsUri}Handle.hash` lazily evaluated
- Make `StoreRecord.{hash,hashType}` lazily evaluated
- Baked-in Google cluster defaults no longer trump values from `loamstream.conf` when using `google { ... }` blocks.

Previously, file hashes were calculated up front for most job outputs, whether or not they were considered. (Ie, if the decision to skip a job or not was made based on file mod time, without even considering hashes, then the hashes still were computed.)  This was a problem for large pipelines operating on large files, since hashing big files is slow.  For example, this PR allows resuming such a pipeline in ~30 minutes, down from ~5.5+ hours.

This PR makes hash computation lazy and ensures the results are cached.  This fixes `--disable-hashing` which didn't have any effect before since hashes were computed up-front and eagerly.  This should also speed up runs when hashing _is_ enabled, by avoiding computing hashes when doing so can be skipped.