### PR TITLE
Quality-Of-Life Improvements Based on Issues Discovered at EBI 

### DIFF
--- a/src/main/scala/loamstream/apps/AppWiring.scala
+++ b/src/main/scala/loamstream/apps/AppWiring.scala
@@ -86,6 +86,7 @@ import loamstream.drm.DrmaaClient
 import loamstream.model.execute.FileSystemExecutionRecorder
 import loamstream.googlecloud.HailCtlDataProcClient
 import loamstream.googlecloud.HailConfig
+import loamstream.model.jobs.JobOracle
 
 
 /**
@@ -478,8 +479,11 @@ object AppWiring extends Loggable {
       val delegate: Executer,
       toStop: Terminable*) extends Executer {
 
-    override def execute(executable: Executable)(implicit timeout: Duration = Duration.Inf): Map[LJob, Execution] = {
-      delegate.execute(executable)(timeout)
+    override def execute(
+        executable: Executable, 
+        makeJobOracle: Executable => JobOracle)(implicit timeout: Duration = Duration.Inf): Map[LJob, Execution] = {
+      
+      delegate.execute(executable, makeJobOracle)(timeout)
     }
 
     override def jobFilter: JobFilter = delegate.jobFilter

--- a/src/main/scala/loamstream/apps/LoamRunner.scala
+++ b/src/main/scala/loamstream/apps/LoamRunner.scala
@@ -12,27 +12,15 @@ import loamstream.util.Loggable
  * @author kyuksel
  * Jun 26, 2017
  */
-trait LoamRunner {
-  def run(project: LoamProject): Either[LoamCompiler.Result, Map[LJob, Execution]]
-}
+final case class LoamRunner(loamEngine: LoamEngine) extends Loggable {
+  def run(project: LoamProject): Either[LoamCompiler.Result, Map[LJob, Execution]] = {
+    val compilationResults = loamEngine.compile(project)
+    
+    info(compilationResults.summary)
 
-object LoamRunner {
-  def apply(loamEngine: LoamEngine): LoamRunner = new Default(loamEngine)
-
-  private val emptyJobResults: Map[LJob, Execution] = Map.empty
-
-  private final class Default(loamEngine: LoamEngine) extends LoamRunner with Loggable {
-
-    override def run(project: LoamProject): Either[LoamCompiler.Result, Map[LJob, Execution]] = {
-
-      val compilationResults = loamEngine.compile(project)
-      
-      info(compilationResults.summary)
-
-      compilationResults match {
-        case success: LoamCompiler.Result.Success => Right(loamEngine.run(success.graph))
-        case _ => Left(compilationResults)
-      }
+    compilationResults match {
+      case success: LoamCompiler.Result.Success => Right(loamEngine.run(success.graph))
+      case _ => Left(compilationResults)
     }
   }
 }

--- a/src/main/scala/loamstream/drm/AccountingCommandInvoker.scala
+++ b/src/main/scala/loamstream/drm/AccountingCommandInvoker.scala
@@ -9,7 +9,7 @@ import loamstream.util.Loggable
  * Apr 25, 2019
  */
 object AccountingCommandInvoker {
-  abstract class Companion[A] extends Loggable {
+  abstract class Companion extends Loggable {
     /**
      * Make a RetryingCommandInvoker that will retrieve job metadata by running some executable.
      */

--- a/src/main/scala/loamstream/drm/JobMonitor.scala
+++ b/src/main/scala/loamstream/drm/JobMonitor.scala
@@ -1,11 +1,15 @@
 package loamstream.drm
 
+import scala.concurrent.duration.DurationDouble
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
+
 import org.ggf.drmaa.InvalidJobException
+
 import loamstream.util.Loggable
 import loamstream.util.Terminable
+import loamstream.util.Tries
 import loamstream.util.ValueBox
 import rx.lang.scala.Observable
 import rx.lang.scala.Scheduler
@@ -13,7 +17,6 @@ import rx.lang.scala.Subject
 import rx.lang.scala.observables.ConnectableObservable
 import rx.lang.scala.schedulers.IOScheduler
 import rx.lang.scala.subjects.PublishSubject
-import scala.concurrent.duration.DurationDouble
 
 /**
  * @author clint
@@ -25,6 +28,11 @@ final class JobMonitor(
     scheduler: Scheduler = IOScheduler(),
     poller: Poller, 
     pollingFrequencyInHz: Double = 1.0) extends Terminable with Loggable {
+  
+  import JobMonitor.allFinished
+  import JobMonitor.demultiplex
+  import JobMonitor.getDrmStatusFor
+  import JobMonitor.unpackThenFilterThenLimit
   
   private[this] val _isStopped: ValueBox[Boolean] = ValueBox(false)
   
@@ -84,7 +92,11 @@ final class JobMonitor(
     //NB: Defensively filter ticks based on isStopped and keepPolling flags to allow "forcibly" stopping polling, 
     //preventing cases where the app is shutting down (and releasing Drmaa resources like Sessions, etc) but 
     //polling, driven by `ticks` keeps going for a little while after.
-    val pollResults = ticks.takeWhile(_ => shouldContinue).map(_ => poll()).until(allFinished(keepPolling)).replay
+    val pollResults = ticks
+      .takeWhile(_ => shouldContinue)
+      .map(_ => poll())
+      .until(allFinished(keepPolling))
+      .replay
     
     val byJobId: Map[String, Observable[Try[DrmStatus]]] = demultiplex(jobIds, pollResults)
 
@@ -97,7 +109,9 @@ final class JobMonitor(
     try { result }
     finally { pollResults.connect }
   }
+}
 
+object JobMonitor extends Loggable {
   /**
    * Transforms the passed Observable by unpacking Trys, filtering out identical consecutive statuses, 
    * and completing when a 'terminal' status is seen.
@@ -156,21 +170,29 @@ final class JobMonitor(
       jobIds: Iterable[String],
       multiplexed: ConnectableObservable[Map[String, Try[DrmStatus]]]): Map[String, Observable[Try[DrmStatus]]] = {
     
+    
     val tuples = for {
       jobId <- jobIds
     } yield {
-      val forJob = multiplexed.map(resultsById => resultsById(jobId))
+      val forJob = multiplexed.map(getDrmStatusFor(jobId))
         
       jobId -> forJob
     }
     
     tuples.toMap
   }
-
+  
+  private[drm] def getDrmStatusFor(jobId: String)(pollResultAttempts: Map[String, Try[DrmStatus]]): Try[DrmStatus] = {
+    pollResultAttempts.get(jobId) match {
+      case Some(pollResultAttempt) => pollResultAttempt
+      case None => Tries.failure(s"No data found for job id '$jobId' when polling, forging onward")
+    }
+  }
+  
   private def allFinished(keepPollingFlag: ValueBox[Boolean])(pollResults: Map[String, Try[DrmStatus]]): Boolean = {
     def unpack(attempt: Try[DrmStatus]): DrmStatus = attempt.getOrElse(DrmStatus.Undetermined)
     
-    val result = pollResults.values.map(unpack).forall(_.isFinished)
+    val result = pollResults.values.iterator.map(unpack).forall(_.isFinished)
     
     if(result) {
       val idsString = pollResults.keys.toSeq.sorted.mkString(",")

--- a/src/main/scala/loamstream/drm/JobMonitor.scala
+++ b/src/main/scala/loamstream/drm/JobMonitor.scala
@@ -170,7 +170,6 @@ object JobMonitor extends Loggable {
       jobIds: Iterable[String],
       multiplexed: ConnectableObservable[Map[String, Try[DrmStatus]]]): Map[String, Observable[Try[DrmStatus]]] = {
     
-    
     val tuples = for {
       jobId <- jobIds
     } yield {

--- a/src/main/scala/loamstream/drm/lsf/BacctAccountingClient.scala
+++ b/src/main/scala/loamstream/drm/lsf/BacctAccountingClient.scala
@@ -75,10 +75,8 @@ final class BacctAccountingClient(
     
     val joinedBacctOutput = rawBacctOutput.mkString(delim).replaceAll(s"${delim}\\s*", "")
     
-    def stripLineEndings(s: String): String = s.replaceAll("\\n?\\r", "")
-    
     def extract(regex: Regex): Option[String] = joinedBacctOutput match {
-      case regex(s) => Option(stripLineEndings(s).trim)
+      case regex(s) => Option(s.trim)
       case _ => None
     }
     

--- a/src/main/scala/loamstream/drm/lsf/BacctInvoker.scala
+++ b/src/main/scala/loamstream/drm/lsf/BacctInvoker.scala
@@ -18,8 +18,6 @@ object BacctInvoker extends AccountingCommandInvoker.Companion {
         actualBinary,
         //long format; displays everything we need, and lots we don't
         "-l", 
-        //"unformatted" output; basically omits some line breaks to make parsing easier
-        "-UF",
         jobId)
   }
 }

--- a/src/main/scala/loamstream/model/execute/Executer.scala
+++ b/src/main/scala/loamstream/model/execute/Executer.scala
@@ -2,7 +2,10 @@ package loamstream.model.execute
 
 import scala.concurrent.duration.Duration
 
-import loamstream.model.jobs.{Execution, LJob}
+import loamstream.conf.ExecutionConfig
+import loamstream.model.jobs.Execution
+import loamstream.model.jobs.JobOracle
+import loamstream.model.jobs.LJob
 import loamstream.util.Terminable
 
 /**
@@ -13,7 +16,9 @@ trait Executer extends Terminable {
 
   def jobFilter: JobFilter 
   
-  def execute(executable: Executable)(implicit timeout: Duration = Duration.Inf): Map[LJob, Execution]
+  def execute(
+      executable: Executable, 
+      makeJobOracle: Executable => JobOracle)(implicit timeout: Duration = Duration.Inf): Map[LJob, Execution]
   
   override def stop(): Unit = ()
   

--- a/src/main/scala/loamstream/model/execute/RxExecuter.scala
+++ b/src/main/scala/loamstream/model/execute/RxExecuter.scala
@@ -52,12 +52,12 @@ final case class RxExecuter(
   require(maxRunsPerJob >= 1, s"The maximum number of times to run each job must not be negative; got $maxRunsPerJob")
   
   import executionRecorder.record
+  import loamstream.util.Observables.Implicits._
   
   override def execute(
       executable: Executable, 
-      makeJobOracle: Executable => JobOracle = JobOracle.fromExecutable(executionConfig, _))(implicit timeout: Duration = Duration.Inf): Map[LJob, Execution] = {
-    
-    import loamstream.util.Observables.Implicits._
+      makeJobOracle: Executable => JobOracle = JobOracle.fromExecutable(executionConfig, _))
+     (implicit timeout: Duration = Duration.Inf): Map[LJob, Execution] = {
     
     val jobOracle = makeJobOracle(executable)
     
@@ -101,12 +101,12 @@ final case class RxExecuter(
     }
     //NB: We no longer stop on the first failure, but run each sub-tree of jobs as far as possible.
     
-    val z: Map[LJob, Execution] = Map.empty
-    
-    val futureMergedResults = chunkResults.foldLeft(z)(_ ++ _).firstAsFuture
+    val futureMergedResults = chunkResults.foldLeft(emptyExecutionMap)(_ ++ _).firstAsFuture
 
     Await.result(futureMergedResults, timeout)
   }
+  
+  private val emptyExecutionMap: Map[LJob, Execution] = Map.empty
   
   private def logFinishedJobs(jobs: Map[LJob, Execution]): Unit = {
     for {

--- a/src/main/scala/loamstream/model/execute/RxExecuter.scala
+++ b/src/main/scala/loamstream/model/execute/RxExecuter.scala
@@ -53,10 +53,13 @@ final case class RxExecuter(
   
   import executionRecorder.record
   
-  override def execute(executable: Executable)(implicit timeout: Duration = Duration.Inf): Map[LJob, Execution] = {
+  override def execute(
+      executable: Executable, 
+      makeJobOracle: Executable => JobOracle = JobOracle.fromExecutable(executionConfig, _))(implicit timeout: Duration = Duration.Inf): Map[LJob, Execution] = {
+    
     import loamstream.util.Observables.Implicits._
     
-    val jobOracle = new JobOracle.ForJobs(executionConfig, executable.allJobs)
+    val jobOracle = makeJobOracle(executable)
     
     val ioScheduler: Scheduler = IOScheduler()
     

--- a/src/main/scala/loamstream/model/jobs/Execution.scala
+++ b/src/main/scala/loamstream/model/jobs/Execution.scala
@@ -38,7 +38,7 @@ final case class Execution(
       environmentAndResourcesMatch, 
       s"Environment type and resources must match, but got $envType and $resources")
       
-  def envType: EnvironmentType = settings.envType
+  override def envType: EnvironmentType = settings.envType
       
   def isSuccess: Boolean = status.isSuccess
   def isFailure: Boolean = status.isFailure

--- a/src/main/scala/loamstream/model/jobs/JobOracle.scala
+++ b/src/main/scala/loamstream/model/jobs/JobOracle.scala
@@ -2,6 +2,7 @@ package loamstream.model.jobs
 
 import java.nio.file.Path
 import loamstream.conf.ExecutionConfig
+import loamstream.model.execute.Executable
 
 /**
  * @author clint
@@ -20,6 +21,10 @@ trait JobOracle {
 }
 
 object JobOracle {
+  def fromExecutable(executionConfig: ExecutionConfig, executable: Executable): JobOracle = {
+    new JobOracle.ForJobs(executionConfig, executable.allJobs)
+  }
+  
   final class ForJobs(executionConfig: ExecutionConfig, jobs: Iterable[LJob]) extends JobOracle {
     private lazy val dirNode: JobDirs.DirNode = JobDirs.allocate(jobs, executionConfig.maxJobLogFilesPerDir)
     

--- a/src/main/scala/loamstream/util/Observables.scala
+++ b/src/main/scala/loamstream/util/Observables.scala
@@ -54,6 +54,8 @@ object Observables extends Loggable {
    * @return an Observable producing map of keys to values
    */
   def toMap[A,B](tuples: Traversable[(A, Observable[B])]): Observable[Map[A,B]] = {
+    //NB: Use merge() instead of folding over the `tuples` Traversable to avoid blowing the stack.
+    
     val tupleObservables: Iterable[Observable[(A, B)]] = tuples.toIterable.map { case (a, bs) => bs.map(b => (a, b)) }
     
     val tupleObs: Observable[(A, B)] = merge(tupleObservables)

--- a/src/main/scala/loamstream/util/Observables.scala
+++ b/src/main/scala/loamstream/util/Observables.scala
@@ -7,6 +7,7 @@ import scala.util.Failure
 import scala.util.Success
 
 import rx.lang.scala.Observable
+import scala.concurrent.duration.Duration
 
 /**
  * @author clint
@@ -53,18 +54,11 @@ object Observables extends Loggable {
    * @return an Observable producing map of keys to values
    */
   def toMap[A,B](tuples: Traversable[(A, Observable[B])]): Observable[Map[A,B]] = {
-    val z: Observable[Map[A,B]] = Observable.just(Map.empty)
+    val tupleObservables: Iterable[Observable[(A, B)]] = tuples.toIterable.map { case (a, bs) => bs.map(b => (a, b)) }
     
-    tuples.foldLeft(z) { (observableAcc, tuple) =>
-      val (a, obsB) = tuple
-      
-      for {
-        acc <- observableAcc
-        b <- obsB
-      } yield {
-        acc + (a -> b)
-      }
-    }
+    val tupleObs: Observable[(A, B)] = merge(tupleObservables)
+    
+    tupleObs.foldLeft(Map.empty[A,B])(_ + _)
   }
   
   /**

--- a/src/test/scala/loamstream/ExecutionResumptionEndToEndTest.scala
+++ b/src/test/scala/loamstream/ExecutionResumptionEndToEndTest.scala
@@ -34,6 +34,7 @@ import loamstream.model.jobs.commandline.CommandLineJob
 import loamstream.util.Loggable
 import loamstream.util.Sequence
 import loamstream.model.jobs.PseudoExecution
+import loamstream.model.jobs.JobOracle
 
 
 
@@ -342,7 +343,7 @@ final class ExecutionResumptionEndToEndTest extends FunSuite with ProvidesSlickL
 
     val executable = LoamEngine.toExecutable(graph)
 
-    val executions = engine.executer.execute(executable)
+    val executions = engine.executer.execute(executable, JobOracle.fromExecutable(engine.config.executionConfig, _))
 
     (executable, executions)
   }

--- a/src/test/scala/loamstream/drm/lsf/BacctAccountingClientTest.scala
+++ b/src/test/scala/loamstream/drm/lsf/BacctAccountingClientTest.scala
@@ -201,9 +201,13 @@ Accounting information about jobs that are:
   - accounted on all service classes.
 ------------------------------------------------------------------------------
 
-Job <2811237>, User <cgilbert>, Project <default>, Status <EXIT>, Queue <research-rh7>, Command <cp ./A.txt ./B.txt>, Share group charged </cgilbert>
+Job <2811237>, User <cgilbert>, Project <default>, Status <EXIT>, Queue <research-
+                     rh7>, Command <cp ./A.txt ./B.txt>, Share group charged </cgi
+                     lbert>
 Thu Apr 18 22:32:01: Submitted from host <ebi-cli-001>, CWD <$HOME>;
-Thu Apr 18 22:32:01: Dispatched to <ebi6-054>, Effective RES_REQ <select[type == local] order[r15s:pg] rusage[numcpus=1.00:duration=8h:decay=0] span[hosts=1] >;
+Thu Apr 18 22:32:01: Dispatched to <ebi6-054>, Effective RES_REQ <select[type == l
+                     ocal] order[r15s:pg] rusage[numcpus=1.00:duration=8h:decay=0]
+                      span[hosts=1] >;
 Thu Apr 18 23:34:12: Completed <exit>.
 
 Accounting information about this job:
@@ -238,9 +242,13 @@ Accounting information about jobs that are:
   - accounted on all service classes.
 ------------------------------------------------------------------------------
 
-Job <2119469>, User <cgilbert>, Project <default>, Status <EXIT>, Queue <research-rh7>, Command <java Hello 250000000 0>, Share group charged </cgilbert>
+Job <2119469>, User <cgilbert>, Project <default>, Status <EXIT>, Queue <research-
+                     rh7>, Command <java Hello 250000000 0>, Share group charged <
+                     /cgilbert>
 Mon May  6 22:58:01: Submitted from host <ebi-cli-001>, CWD <$$HOME>;
-Mon May  6 22:58:03: Dispatched to <ebi6-142>, Effective RES_REQ <select[type == local] order[r15s:pg] rusage[mem=1000.00:duration=8h:decay=0,numcpus=1.00:duration=8h:decay=0] span[hosts=1] >;
+Mon May  6 22:58:03: Dispatched to <ebi6-142>, Effective RES_REQ <select[type == l
+                     ocal] order[r15s:pg] rusage[mem=1000.00:duration=8h:decay=0,n
+                     umcpus=1.00:duration=8h:decay=0] span[hosts=1] >;
 Mon May  6 22:58:03: Completed <exit>; ${termReason}: ${termDesc}
 
 Accounting information about this job:

--- a/src/test/scala/loamstream/drm/lsf/BacctInvokerTest.scala
+++ b/src/test/scala/loamstream/drm/lsf/BacctInvokerTest.scala
@@ -8,6 +8,6 @@ import org.scalatest.FunSuite
  */
 final class BacctInvokerTest extends FunSuite {
   test("makeTokens") {
-    assert(BacctInvoker.makeTokens("foo", "bar") === Seq("foo", "-l", "-UF", "bar"))
+    assert(BacctInvoker.makeTokens("foo", "bar") === Seq("foo", "-l", "bar"))
   }
 }

--- a/src/test/scala/loamstream/model/execute/ExecutionResumptionTest.scala
+++ b/src/test/scala/loamstream/model/execute/ExecutionResumptionTest.scala
@@ -156,7 +156,7 @@ final class ExecutionResumptionTest extends FunSuite with ProvidesSlickLoamDao w
   
   private def runWithExecuter(
       runningEverything: Boolean,
-      executer: Executer,
+      executer: RxExecuter,
       executable: Executable,
       mockJobs: (MockJob, MockJob, MockJob),
       expectations: Seq[JobStatus],

--- a/src/test/scala/loamstream/util/ObservablesTest.scala
+++ b/src/test/scala/loamstream/util/ObservablesTest.scala
@@ -137,8 +137,8 @@ final class ObservablesTest extends FunSuite {
     
     {
       val tuples = Seq("a" -> Observable.just(1), "b" -> Observable.just(2, 22), "c" -> Observable.just(3))
-      
-      val expected = Seq(Map("a" -> 1, "b" -> 2, "c" -> 3), Map("a" -> 1, "b" -> 22, "c" -> 3))
+
+      val expected = Seq(Map("a" -> 1, "b" -> 22, "c" -> 3))
       
       assert(waitFor(toMap(tuples).to[Seq].firstAsFuture) == expected)
     }


### PR DESCRIPTION
- Job-polling "successes" where no data is returned should no longer crash LS.
- The .tsv index files are written in more cases.  In particular, if LS crashes during pipeline execution, the .tsvs will be written with as much information as is readily available, notably jobs' directories under `.loamstream/jobs/data`.
- Shorter stack traces in some situations (uses less stack, and makes logs easier to read).
- Don't pass `-UF` to `bacct` now that EBI has upgraded their LSF cluster to 10.x.

Unit and integration tests pass.