### PR TITLE
Retry Accounting Clients Asynchronously

### DIFF
--- a/src/main/scala/loamstream/drm/AccountingClient.scala
+++ b/src/main/scala/loamstream/drm/AccountingClient.scala
@@ -12,6 +12,8 @@ import loamstream.util.Tries
 import loamstream.util.Loops
 import loamstream.model.execute.Resources.DrmResources
 import loamstream.model.jobs.TerminationReason
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext
 
 /**
  * @author clint
@@ -20,11 +22,11 @@ import loamstream.model.jobs.TerminationReason
  * An abstraction for getting some environment-specific metadata that can't currently be accessed via DRMAA
  */
 trait AccountingClient {
-  def getResourceUsage(jobId: String): Try[DrmResources]
+  def getResourceUsage(jobId: String): Future[DrmResources]
   
-  def getTerminationReason(jobId: String): Try[Option[TerminationReason]]
+  def getTerminationReason(jobId: String): Future[Option[TerminationReason]]
   
-  def getAccountingInfo(jobId: String): Try[AccountingInfo] = {
+  def getAccountingInfo(jobId: String)(implicit ex: ExecutionContext): Future[AccountingInfo] = {
     for {
       rs <- getResourceUsage(jobId)
       tr <- getTerminationReason(jobId)

--- a/src/main/scala/loamstream/drm/AccountingClient.scala
+++ b/src/main/scala/loamstream/drm/AccountingClient.scala
@@ -1,19 +1,10 @@
 package loamstream.drm
 
-import scala.concurrent.duration._
-import scala.util.Try
-import scala.util.Success
-import scala.util.Failure
-import loamstream.util.Loggable
-import loamstream.util.Functions
-import loamstream.util.RunResults
-import loamstream.util.Processes
-import loamstream.util.Tries
-import loamstream.util.Loops
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
 import loamstream.model.execute.Resources.DrmResources
 import loamstream.model.jobs.TerminationReason
-import scala.concurrent.Future
-import scala.concurrent.ExecutionContext
 
 /**
  * @author clint

--- a/src/main/scala/loamstream/drm/AccountingCommandInvoker.scala
+++ b/src/main/scala/loamstream/drm/AccountingCommandInvoker.scala
@@ -3,6 +3,7 @@ package loamstream.drm
 import loamstream.util.RetryingCommandInvoker
 import loamstream.util.Processes
 import loamstream.util.Loggable
+import scala.concurrent.ExecutionContext
 
 /**
  * @author clint
@@ -13,7 +14,7 @@ object AccountingCommandInvoker {
     /**
      * Make a RetryingCommandInvoker that will retrieve job metadata by running some executable.
      */
-    def useActualBinary(maxRetries: Int, binaryName: String): RetryingCommandInvoker[String] = {
+    def useActualBinary(maxRetries: Int, binaryName: String)(implicit ec: ExecutionContext): RetryingCommandInvoker[String] = {
       def invokeBinaryFor(jobId: String) = {
         val tokens = makeTokens(binaryName, jobId)
         

--- a/src/main/scala/loamstream/drm/AccountingCommandInvoker.scala
+++ b/src/main/scala/loamstream/drm/AccountingCommandInvoker.scala
@@ -1,9 +1,10 @@
 package loamstream.drm
 
-import loamstream.util.RetryingCommandInvoker
-import loamstream.util.Processes
-import loamstream.util.Loggable
 import scala.concurrent.ExecutionContext
+
+import loamstream.util.Loggable
+import loamstream.util.Processes
+import loamstream.util.RetryingCommandInvoker
 
 /**
  * @author clint

--- a/src/main/scala/loamstream/drm/AccountingCommandInvoker.scala
+++ b/src/main/scala/loamstream/drm/AccountingCommandInvoker.scala
@@ -14,7 +14,10 @@ object AccountingCommandInvoker {
     /**
      * Make a RetryingCommandInvoker that will retrieve job metadata by running some executable.
      */
-    def useActualBinary(maxRetries: Int, binaryName: String)(implicit ec: ExecutionContext): RetryingCommandInvoker[String] = {
+    def useActualBinary(
+        maxRetries: Int, 
+        binaryName: String)(implicit ec: ExecutionContext): RetryingCommandInvoker[String] = {
+      
       def invokeBinaryFor(jobId: String) = {
         val tokens = makeTokens(binaryName, jobId)
         

--- a/src/main/scala/loamstream/drm/DrmChunkRunner.scala
+++ b/src/main/scala/loamstream/drm/DrmChunkRunner.scala
@@ -172,7 +172,8 @@ object DrmChunkRunner extends Loggable {
     }
   }
   
-  private[drm] def getAccountingInfoFor(accountingClient: AccountingClient)(jobId: String)(implicit ec: ExecutionContext): Future[Option[AccountingInfo]] = {
+  private[drm] def getAccountingInfoFor(accountingClient: AccountingClient)(jobId: String)
+                                       (implicit ec: ExecutionContext): Future[Option[AccountingInfo]] = {
     val infoAttempt = accountingClient.getAccountingInfo(jobId)
         
     //For side effect only
@@ -221,7 +222,8 @@ object DrmChunkRunner extends Loggable {
   private[drm] def toRunDatas(
     accountingClient: AccountingClient, 
     shouldRestart: LJob => Boolean,
-    jobsAndDrmStatusesById: Map[String, JobAndStatuses])(implicit ec: ExecutionContext): Observable[Map[LJob, RunData]] = {
+    jobsAndDrmStatusesById: Map[String, JobAndStatuses])
+    (implicit ec: ExecutionContext): Observable[Map[LJob, RunData]] = {
 
     val drmJobsToExecutionObservables: Iterable[(DrmJobWrapper, Observable[RunData])] = for {
       (jobId, (wrapper, drmJobStatuses)) <- jobsAndDrmStatusesById

--- a/src/main/scala/loamstream/drm/DrmChunkRunner.scala
+++ b/src/main/scala/loamstream/drm/DrmChunkRunner.scala
@@ -1,5 +1,8 @@
 package loamstream.drm
 
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
 import DrmStatus.toJobResult
 import DrmStatus.toJobStatus
 import loamstream.conf.DrmConfig
@@ -22,9 +25,6 @@ import loamstream.util.Loggable
 import loamstream.util.Observables
 import loamstream.util.Terminable
 import rx.lang.scala.Observable
-import scala.concurrent.Future
-import scala.concurrent.ExecutionContext
-import scala.util.Success
 
 
 /**

--- a/src/main/scala/loamstream/drm/lsf/BacctAccountingClient.scala
+++ b/src/main/scala/loamstream/drm/lsf/BacctAccountingClient.scala
@@ -6,6 +6,8 @@ import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeFormatterBuilder
 import java.time.temporal.ChronoField
 
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
 import scala.util.Success
 import scala.util.Try
 import scala.util.matching.Regex
@@ -14,15 +16,13 @@ import loamstream.conf.LsfConfig
 import loamstream.drm.AccountingClient
 import loamstream.drm.Queue
 import loamstream.model.execute.Resources.LsfResources
+import loamstream.model.jobs.TerminationReason
 import loamstream.model.quantities.CpuTime
 import loamstream.model.quantities.Memory
 import loamstream.util.Loggable
 import loamstream.util.Options
 import loamstream.util.RetryingCommandInvoker
 import loamstream.util.Tries
-import loamstream.model.jobs.TerminationReason
-import scala.concurrent.Future
-import scala.concurrent.ExecutionContext
 
 /**
  * @author clint

--- a/src/main/scala/loamstream/drm/uger/QacctAccountingClient.scala
+++ b/src/main/scala/loamstream/drm/uger/QacctAccountingClient.scala
@@ -6,6 +6,8 @@ import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeFormatterBuilder
 
 import scala.collection.Seq
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
 import scala.concurrent.duration.DurationDouble
 import scala.util.Try
 import scala.util.matching.Regex
@@ -14,17 +16,13 @@ import loamstream.conf.UgerConfig
 import loamstream.drm.AccountingClient
 import loamstream.drm.Queue
 import loamstream.model.execute.Resources.UgerResources
+import loamstream.model.jobs.TerminationReason
 import loamstream.model.quantities.CpuTime
 import loamstream.model.quantities.Memory
 import loamstream.util.Loggable
 import loamstream.util.Options
 import loamstream.util.RetryingCommandInvoker
 import loamstream.util.Tries
-import loamstream.model.jobs.TerminationReason
-import scala.util.Success
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
-import loamstream.util.Futures
 
 /**
  * @author clint

--- a/src/main/scala/loamstream/util/Futures.scala
+++ b/src/main/scala/loamstream/util/Futures.scala
@@ -5,6 +5,7 @@ import scala.concurrent.Future
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
+import scala.util.Try
 
 /**
  * @author clint

--- a/src/main/scala/loamstream/util/Loops.scala
+++ b/src/main/scala/loamstream/util/Loops.scala
@@ -3,6 +3,11 @@ package loamstream.util
 import scala.util.Try
 import scala.concurrent.duration._
 import scala.util.Success
+import scala.concurrent.Future
+import rx.lang.scala.Observable
+import scala.concurrent.Promise
+import scala.concurrent.ExecutionContext
+import scala.util.Failure
 
 /**
  * @author clint
@@ -50,6 +55,33 @@ object Loops {
     attempts.toStream.headOption match {
       case Some(Success(a)) => Some(a)
       case _ => None
+    }
+  }
+  
+  def retryUntilSuccessWithBackoffAsync[A](
+      maxRuns: Int, 
+      delayStart: Duration, 
+      delayCap: Duration)(op: => Try[A])(implicit ec: ExecutionContext): Future[Option[A]] = {
+    
+    val delays = Backoff.delaySequence(delayStart, delayCap)
+    
+    def delayAndThen[X](f: => X): Observable[X] = Observable.timer(delays.next()).map(_ => f)
+    
+    def next(tuple: (Int, Try[A])): Observable[(Int, Try[A])] = {
+      val (i, attempt) = tuple
+      
+      attempt match {
+        case Success(_) => Observable.just(tuple)
+        case Failure(_) if i >= maxRuns => Observable.empty
+        case _ => delayAndThen((i + 1) -> op).flatMap(next)
+      }
+    }
+    if(maxRuns == 0) { 
+      Future.successful(None)
+    } else {
+      import Observables.Implicits._
+      
+      next(1 -> op).collect { case (_, attempt) => attempt.toOption }.headOption.map(_.flatten).firstAsFuture
     }
   }
 }

--- a/src/main/scala/loamstream/util/Loops.scala
+++ b/src/main/scala/loamstream/util/Loops.scala
@@ -1,13 +1,14 @@
 package loamstream.util
 
-import scala.util.Try
-import scala.concurrent.duration._
-import scala.util.Success
-import scala.concurrent.Future
-import rx.lang.scala.Observable
-import scala.concurrent.Promise
 import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.duration.Duration
+import scala.concurrent.duration.DurationInt
 import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+
+import rx.lang.scala.Observable
 
 /**
  * @author clint

--- a/src/main/scala/loamstream/util/RetryingCommandInvoker.scala
+++ b/src/main/scala/loamstream/util/RetryingCommandInvoker.scala
@@ -24,7 +24,8 @@ final class RetryingCommandInvoker[A](
     binaryName: String,
     delegateFn: InvocationFn[A],
     delayStart: Duration = RetryingCommandInvoker.defaultDelayStart,
-    delayCap: Duration = RetryingCommandInvoker.defaultDelayCap)(implicit ec: ExecutionContext) extends (SuccessfulInvocationFn[A]) with Loggable {
+    delayCap: Duration = RetryingCommandInvoker.defaultDelayCap)
+    (implicit ec: ExecutionContext) extends (SuccessfulInvocationFn[A]) with Loggable {
   
   //Memoize the function that retrieves the metadata, to avoid running something expensive, like invoking
   //bacct/qacct, more than necessary.

--- a/src/main/scala/loamstream/util/RetryingCommandInvoker.scala
+++ b/src/main/scala/loamstream/util/RetryingCommandInvoker.scala
@@ -6,6 +6,8 @@ import RetryingCommandInvoker.InvocationFn
 import RetryingCommandInvoker.SuccessfulInvocationFn
 import scala.util.Success
 import scala.util.Failure
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext
 
 /**
  * @author clint
@@ -22,13 +24,13 @@ final class RetryingCommandInvoker[A](
     binaryName: String,
     delegateFn: InvocationFn[A],
     delayStart: Duration = RetryingCommandInvoker.defaultDelayStart,
-    delayCap: Duration = RetryingCommandInvoker.defaultDelayCap) extends (SuccessfulInvocationFn[A]) with Loggable {
+    delayCap: Duration = RetryingCommandInvoker.defaultDelayCap)(implicit ec: ExecutionContext) extends (SuccessfulInvocationFn[A]) with Loggable {
   
   //Memoize the function that retrieves the metadata, to avoid running something expensive, like invoking
   //bacct/qacct, more than necessary.
   //NB: If the operation fails, retry up to maxRetries times, by default waiting 
   //0.5, 1, 2, 4, ... up to 30s in between each one.
-  override def apply(param: A): Try[RunResults.Successful] = runCommand(param)
+  override def apply(param: A): Future[RunResults.Successful] = runCommand(param)
   
   private val runCommand: SuccessfulInvocationFn[A] = {
     doRetries(
@@ -62,18 +64,18 @@ final class RetryingCommandInvoker[A](
       case Failure(e) => Failure(e)
     }
     
-    val resultOpt = Loops.retryUntilSuccessWithBackoff(maxRuns, delayStart, delayCap) {
+    val resultOptFuture = Loops.retryUntilSuccessWithBackoffAsync(maxRuns, delayStart, delayCap) {
       invokeBinary()
     }
     
-    val result: Try[RunResults.Successful] = resultOpt match {
-      case Some(a) => Success(a)
+    val result: Future[RunResults.Successful] = resultOptFuture.flatMap {
+      case Some(a) => Future.successful(a)
       case _ => {
         val msg = s"Invoking '$binaryName' for with param '$param' failed after $maxRuns runs"
         
         debug(msg)
 
-        Tries.failure(msg)
+        Future.failed(new Exception(msg))
       }
     }
     
@@ -84,7 +86,7 @@ final class RetryingCommandInvoker[A](
 object RetryingCommandInvoker {
   type InvocationFn[A] = A => Try[RunResults]
   
-  type SuccessfulInvocationFn[A] = A => Try[RunResults.Successful]
+  type SuccessfulInvocationFn[A] = A => Future[RunResults.Successful]
   
   import scala.concurrent.duration._
   

--- a/src/main/scala/loamstream/util/RetryingCommandInvoker.scala
+++ b/src/main/scala/loamstream/util/RetryingCommandInvoker.scala
@@ -1,13 +1,14 @@
 package loamstream.util
 
-import scala.util.Try
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
 import scala.concurrent.duration.Duration
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+
 import RetryingCommandInvoker.InvocationFn
 import RetryingCommandInvoker.SuccessfulInvocationFn
-import scala.util.Success
-import scala.util.Failure
-import scala.concurrent.Future
-import scala.concurrent.ExecutionContext
 
 /**
  * @author clint

--- a/src/test/scala/loamstream/drm/DrmChunkRunnerTest.scala
+++ b/src/test/scala/loamstream/drm/DrmChunkRunnerTest.scala
@@ -56,6 +56,7 @@ final class DrmChunkRunnerTest extends FunSuite {
   import loamstream.TestHelpers.neverRestart
   import loamstream.model.jobs.JobStatus.FailedPermanently
   import loamstream.model.jobs.JobStatus.Succeeded
+  import scala.concurrent.ExecutionContext.Implicits.global
   
   private val tempDir = TestHelpers.getWorkDir(getClass.getSimpleName) 
   

--- a/src/test/scala/loamstream/drm/MockAccountingClient.scala
+++ b/src/test/scala/loamstream/drm/MockAccountingClient.scala
@@ -4,6 +4,7 @@ import scala.util.Try
 import loamstream.model.execute.Resources.DrmResources
 import loamstream.util.Tries
 import loamstream.model.jobs.TerminationReason
+import scala.concurrent.Future
 
 /**
  * @author clint
@@ -11,8 +12,10 @@ import loamstream.model.jobs.TerminationReason
  */
 object MockAccountingClient {
   object NeverWorks extends AccountingClient {
-    override def getResourceUsage(jobId: String): Try[DrmResources] = Tries.failure("MOCK")
+    override def getResourceUsage(jobId: String): Future[DrmResources] = Future.fromTry(Tries.failure("MOCK"))
     
-    override def getTerminationReason(jobId: String): Try[Option[TerminationReason]] = Tries.failure("MOCK")
+    override def getTerminationReason(jobId: String): Future[Option[TerminationReason]] = {
+      Future.fromTry(Tries.failure("MOCK"))
+    }
   }
 }

--- a/src/test/scala/loamstream/drm/uger/MockQacctAccountingClient.scala
+++ b/src/test/scala/loamstream/drm/uger/MockQacctAccountingClient.scala
@@ -11,6 +11,7 @@ import scala.util.Success
 import loamstream.model.execute.Resources.DrmResources
 import loamstream.util.RetryingCommandInvoker
 import loamstream.model.jobs.TerminationReason
+import scala.concurrent.Future
 
 /**
  * @author clint
@@ -43,6 +44,8 @@ final class MockQacctAccountingClient(
       delegateFn(jobId)
     }
 
+    import scala.concurrent.ExecutionContext.Implicits.global
+    
     val invoker = {
       new RetryingCommandInvoker[String](ugerConfig.maxQacctRetries, "MOCK", wrappedDelegateFn, delayStart, delayCap)
     }
@@ -50,13 +53,13 @@ final class MockQacctAccountingClient(
     new QacctAccountingClient(invoker)
   }
 
-  override def getResourceUsage(jobId: String): Try[DrmResources] = {
+  override def getResourceUsage(jobId: String): Future[DrmResources] = {
     timesGetResourceUsageInvokedBox.mutate(_ + 1)
     
     actualDelegate.getResourceUsage(jobId)
   }
   
-  override def getTerminationReason(jobId: String): Try[Option[TerminationReason]] = {
+  override def getTerminationReason(jobId: String): Future[Option[TerminationReason]] = {
     timesGetTerminationReasonInvokedBox.mutate(_ + 1)
     
     actualDelegate.getTerminationReason(jobId)


### PR DESCRIPTION
- Wait for `{b,q}acct` retries asynchronously, instead of using `Thread.sleep()`
- Add `Loops.retryUntilSuccessWithBackoffAsync()`

Unit and integration tests pass.