### PR TITLE
Make sure default uncaught exception handler shuts down Loamstream

### DIFF
--- a/src/test/scala/loamstream/apps/MainTest.scala
+++ b/src/test/scala/loamstream/apps/MainTest.scala
@@ -31,19 +31,17 @@ final class MainTest extends FunSuite {
   test("shutdown") {
     val mockWiring = new MainTest.MockAppWiring
     
-    val run = new Main.Run
-    
     assert(mockWiring.shutdownInvocations === 0)
     
-    run.shutdown(mockWiring)
+    Main.shutdown(mockWiring)
     
     assert(mockWiring.shutdownInvocations === 1)
     
-    run.shutdown(mockWiring)
+    Main.shutdown(mockWiring)
     
     assert(mockWiring.shutdownInvocations === 1)
     
-    run.shutdown(mockWiring)
+    Main.shutdown(mockWiring)
     
     assert(mockWiring.shutdownInvocations === 1)
   }


### PR DESCRIPTION
Make a stronger guarantee (in the face of `Error`s, especially `OutOfMemoryError`, all bets are off) that LS shuts down as gracefully as possible if any thread encounters an uncaught, fatal Exception.  This is motivated by a run where an OOM Error caused several worker threads - but not the main one - to die, leading to LS limping along in a state that would never finish or do useful work.