### PR TITLE
Invoke AccountingClients only for jobs that finish unsuccessfully

### DIFF
--- a/src/main/scala/loamstream/loam/intake/ColumnExpr.scala
+++ b/src/main/scala/loamstream/loam/intake/ColumnExpr.scala
@@ -36,16 +36,16 @@ sealed abstract class ColumnExpr[A : TypeTag] extends RowParser[A] {
   
   final def asUpperCase(implicit ev: A =:= String): ColumnExpr[String] = this.map(a => ev(a).toUpperCase)
   
-  final def -(expr: ColumnExpr[A])(implicit ev: Numeric[A]): ColumnExpr[A] = arithmeticOp(expr)(_.minus)
+  final def -(rhs: ColumnExpr[A])(implicit ev: Numeric[A]): ColumnExpr[A] = arithmeticOp(this, rhs)(_.minus)
     
-  final def +(expr: ColumnExpr[A])(implicit ev: Numeric[A]): ColumnExpr[A] = arithmeticOp(expr)(_.plus)
+  final def +(rhs: ColumnExpr[A])(implicit ev: Numeric[A]): ColumnExpr[A] = arithmeticOp(this, rhs)(_.plus)
     
-  final def *(expr: ColumnExpr[A])(implicit ev: Numeric[A]): ColumnExpr[A] = arithmeticOp(expr)(_.times)
+  final def *(rhs: ColumnExpr[A])(implicit ev: Numeric[A]): ColumnExpr[A] = arithmeticOp(this, rhs)(_.times)
   
-  final def /(expr: ColumnExpr[A])(implicit ev: Fractional[A]): ColumnExpr[A] = {
+  final def /(rhs: ColumnExpr[A])(implicit ev: Fractional[A]): ColumnExpr[A] = {
     val fractional = implicitly[Fractional[A]]
     
-    ColumnExpr.lift2(fractional.div).apply(this, expr)
+    ColumnExpr.lift2(fractional.div).apply(this, rhs)
   }
   
   final def unary_-(implicit ev: Numeric[A]): ColumnExpr[A] = {
@@ -89,14 +89,6 @@ sealed abstract class ColumnExpr[A : TypeTag] extends RowParser[A] {
   final def <=(rhs: A)(implicit ev: Ordering[A]): RowPredicate = this.map(lhs => ev.lteq(lhs, rhs))
   final def >(rhs: A)(implicit ev: Ordering[A]): RowPredicate = this.map(lhs => ev.gt(lhs, rhs))
   final def >=(rhs: A)(implicit ev: Ordering[A]): RowPredicate = this.map(lhs => ev.gteq(lhs, rhs))
-    
-  private def arithmeticOp(
-      expr: ColumnExpr[A])(op: Numeric[A] => (A, A) => A)(implicit ev: Numeric[A]): ColumnExpr[A] = {
-
-    val f = op(implicitly[Numeric[A]])
-    
-    ColumnExpr.lift2(f).apply(this, expr)
-  }
 }
 
 object ColumnExpr {
@@ -146,6 +138,15 @@ object ColumnExpr {
       lhs <- lhsExpr
       rhs <- rhsExpr
     } yield f(lhs, rhs)
+  }
+      
+  private def arithmeticOp[A : TypeTag](
+      lhs: ColumnExpr[A],
+      rhs: ColumnExpr[A])(op: Numeric[A] => (A, A) => A)(implicit ev: Numeric[A]): ColumnExpr[A] = {
+
+    val f = op(implicitly[Numeric[A]])
+    
+    lift2(f).apply(lhs, rhs)
   }
 }
 


### PR DESCRIPTION
Running accounting clients (the things that ultimately invoke `qacct` et al) for every job is slow, and batching up jobs to invoke `qacct` on the whole batch has undesirable side effects without a more major refactoring.  What's more, the data obtained from qacct is very rarely useful unless a job fails.

This branch changes `DrmChunkRunner` to only invoke `AccountingClient`s for finished, non-successful jobs.
