### PR TITLE
Don't use classes from javax.xml.bind

### DIFF
--- a/src/main/scala/loamstream/googlecloud/GcsCloudStorageClient.scala
+++ b/src/main/scala/loamstream/googlecloud/GcsCloudStorageClient.scala
@@ -2,12 +2,16 @@ package loamstream.googlecloud
 
 import java.net.URI
 import java.time.Instant
-import javax.xml.bind.DatatypeConverter
 
+import loamstream.util.Base64
+import loamstream.util.Hash
+import loamstream.util.Hashes
+import loamstream.util.HashType
 import loamstream.util.HashType.Md5
-import loamstream.util._
+import loamstream.util.Loggable
 
 import scala.util.Try
+
 
 /**
  * @author kyuksel
@@ -31,7 +35,7 @@ final case class GcsCloudStorageClient(driver: CloudStorageDriver) extends Cloud
       //For multiple blobs, as will be the case for a 'directory', hash their (Google-supplied) hashes
       case _ => {
         val hashStrings: Iterator[String] = bs.map(_.hash).toArray.sorted.toIterator
-        val hashBytes = hashStrings.map(DatatypeConverter.parseBase64Binary)
+        val hashBytes = hashStrings.map(Base64.decode)
 
         Option(Hashes.digest(hashAlgorithm)(hashBytes))
       }

--- a/src/main/scala/loamstream/util/Base64.scala
+++ b/src/main/scala/loamstream/util/Base64.scala
@@ -1,0 +1,11 @@
+package loamstream.util
+
+/**
+ * @author clint
+ * date: Jun 4, 2020
+ */
+object Base64 {
+  def encode(data: Array[Byte]): String = org.apache.commons.codec.binary.Base64.encodeBase64String(data)
+
+  def decode(s: String): Array[Byte] = org.apache.commons.codec.binary.Base64.decodeBase64(s)
+}

--- a/src/main/scala/loamstream/util/Hash.scala
+++ b/src/main/scala/loamstream/util/Hash.scala
@@ -1,7 +1,5 @@
 package loamstream.util
 
-import javax.xml.bind.DatatypeConverter
-
 import scala.collection.mutable
 
 /**
@@ -14,13 +12,13 @@ final case class Hash(value: mutable.WrappedArray[Byte], tpe: HashType) {
   
   override def toString: String = s"$tpe($valueAsBase64String)"
   
-  def valueAsBase64String: String = DatatypeConverter.printBase64Binary(value.toArray)
+  def valueAsBase64String: String = Base64.encode(value.toArray)
 }
 
 object Hash {
   def fromStrings(value: Option[String], tpe: String): Option[Hash] = {
     for {
-      bytes <- value.map(DatatypeConverter.parseBase64Binary)
+      bytes <- value.map(Base64.decode)
       hashType <- HashType.fromAlgorithmName(tpe)
     } yield Hash(bytes, hashType)
   }

--- a/src/test/scala/loamstream/util/Base64Test.scala
+++ b/src/test/scala/loamstream/util/Base64Test.scala
@@ -1,0 +1,25 @@
+package loamstream.util
+
+import org.scalatest.FunSuite
+
+/**
+ * @author clint
+ * Jun 5, 2020
+ */
+final class Base64Test extends FunSuite {
+  import Base64.{encode, decode}
+
+  private val someBytes = "FOO lalala".getBytes
+
+  test("encode") {
+    assert(encode(someBytes) === "Rk9PIGxhbGFsYQ==")
+
+	assert(encode(Array.empty) === "")
+  }
+
+  test("decode") {
+    assert(decode("Rk9PIGxhbGFsYQ==") === someBytes)
+
+    assert(decode("") === Array.empty[Byte])
+  }
+}


### PR DESCRIPTION
Don't use any classes from `javax.xml.bind`, particularly `DatatypeConverter`, as this package is not bundled with the JRE post-Java-8.