### PR TITLE
Cache fasta reference files in memory

### DIFF
--- a/src/main/scala/loamstream/loam/intake/flip/ReferenceFileHandle.scala
+++ b/src/main/scala/loamstream/loam/intake/flip/ReferenceFileHandle.scala
@@ -6,50 +6,117 @@ import java.io.Reader
 import java.io.InputStreamReader
 import java.util.zip.GZIPInputStream
 import java.io.FileInputStream
+import java.nio.file.Path
+import java.lang.ref.WeakReference
+import java.io.InputStream
+import org.apache.commons.io.IOUtils
 
 /**
  * @author clint
  * Apr 1, 2020
  */
-final class ReferenceFileHandle(makeNewReader: => Reader) {
-  def readAt(i: Long): Option[Char] = {
-    CanBeClosed.enclosed(makeNewReader) { reader =>
-      val numSkipped = reader.skip(i)
-    
-      if(numSkipped == i) {
-        val ch = reader.read()
-        
-        if(ch >= 0) { Some(ch.toChar) }
-        else { None }
-      } 
-      else { None }
-    }
-  }
+trait ReferenceFileHandle {
+  def readAt(i: Long): Option[Char]
   
-  def readAt(start: Long, length: Int): Option[String] = {
-    val arr: Array[Char] = Array.ofDim(length)
-    
-    CanBeClosed.enclosed(makeNewReader) { reader =>
-      def read(): Option[String] = {
-        val numRead = reader.read(arr, 0, length)
-      
-        if(numRead == length) Some(arr.mkString) else None
-      }
-      
-      val numSkipped = reader.skip(start)
-      
-      if(numSkipped == start) read() else None
-    }
-  }
+  def readAt(start: Long, length: Int): Option[String]
 }
 
 object ReferenceFileHandle {
-  def apply(file: java.io.File): ReferenceFileHandle = {
-    if(file.toString.endsWith("gz")) { ReferenceFileHandle.fromGzippedFile(file) }
-    else { new ReferenceFileHandle(new FileReader(file)) }
+  def apply(file: java.io.File, inMemory: Boolean = false): ReferenceFileHandle = {
+    if(file.toString.endsWith("gz")) { fromGzippedFile(file, inMemory) }
+    else { fromUnzippedFile(file, inMemory) }
   }
   
-  def fromGzippedFile(file: java.io.File): ReferenceFileHandle = {
-    new ReferenceFileHandle(new InputStreamReader(new GZIPInputStream(new FileInputStream(file))))
+  def fromUnzippedFile(file: java.io.File, inMemory: Boolean = false): ReferenceFileHandle = {
+    fromStream(new FileInputStream(file), inMemory)
+  }
+  
+  def fromGzippedFile(file: java.io.File, inMemory: Boolean = false): ReferenceFileHandle = {
+    fromStream(new GZIPInputStream(new FileInputStream(file)), inMemory)
+  }
+  
+  private def fromStream(newStream: => InputStream, inMemory: Boolean): ReferenceFileHandle = {
+    if(inMemory) { new InMemory(newStream) }
+    else { new OnDisk(new InputStreamReader(newStream)) }
+  }
+    
+  final class InMemory(newStream: => InputStream) extends ReferenceFileHandle {
+    private var dataRef: WeakReference[Array[Byte]] = _
+    
+    private def dataOpt: Option[Array[Byte]] = Option(dataRef).flatMap(ref => Option(ref.get)) 
+    
+    private def getData: Array[Byte] = dataOpt match {
+      case Some(data) => data
+      case None => {
+        val data = CanBeClosed.enclosed(newStream)(IOUtils.toByteArray)
+        
+        dataRef = new WeakReference(data)
+        
+        data
+      }
+    }
+    
+    private def withData[A](f: Array[Byte] => A): A = f(getData)
+    
+    override def readAt(i: Long): Option[Char] = {
+      require(i >= 0)
+      
+      withData { data =>
+        if(i < data.length) { Some(data(i.toInt).toChar) }
+        else { None }
+      }
+    }
+    
+    override def readAt(start: Long, length: Int): Option[String] = {
+      require(start >= 0)
+      
+      withData { data =>
+        val end = start + length
+        
+        val available = data.length - start
+        
+        if(end > data.length) { None }
+        else if(available < length) { None }
+        else {
+          val arr: Array[Byte] = Array.ofDim(length)
+          
+          Array.copy(data, start.toInt, arr, 0, length)
+          
+          Some(arr.iterator.map(_.toChar).mkString) 
+        }
+      }
+    }
+  }
+  
+  final class OnDisk(makeNewReader: => Reader) extends ReferenceFileHandle {
+    override def readAt(i: Long): Option[Char] = {
+      CanBeClosed.enclosed(makeNewReader) { reader =>
+        val numSkipped = reader.skip(i)
+      
+        if(numSkipped == i) {
+          val ch = reader.read()
+          
+          if(ch >= 0) { Some(ch.toChar) }
+          else { None }
+        } 
+        else { None }
+      }
+    }
+    
+    override def readAt(start: Long, length: Int): Option[String] = {
+      val arr: Array[Char] = Array.ofDim(length)
+      
+      CanBeClosed.enclosed(makeNewReader) { reader =>
+        def read(): Option[String] = {
+          val numRead = reader.read(arr, 0, length)
+        
+          if(numRead == length) Some(arr.mkString) else None
+        }
+        
+        val numSkipped = reader.skip(start)
+        
+        if(numSkipped == start) read() else None
+      }
+    }
   }
 }

--- a/src/main/scala/loamstream/loam/intake/flip/ReferenceFileHandle.scala
+++ b/src/main/scala/loamstream/loam/intake/flip/ReferenceFileHandle.scala
@@ -14,6 +14,16 @@ import org.apache.commons.io.IOUtils
 /**
  * @author clint
  * Apr 1, 2020
+ * 
+ * A trait to represent a reference (.fasta) file.  There are two implementations: InMemory, which loads whole
+ * reference files into memory as byte arrays and is very fast, and OnDisk, which doesn't load files into memory
+ * and is significantly slower.
+ * 
+ * Both files make the same assumptions that the Perl code this is based on do: that the reference files contain 
+ * a sequence of 1-byte characters with no gaps, where the index of a byte in the file directly corresponds to a
+ * position on the reference genome.  The reference files we have for this purpose fit the above, and are technically
+ * .fasta files, but no attempt is made here (or in the original Perl code) to handle fasta-format features like 
+ * comments, spaces, multiple lines, etc etc. 
  */
 trait ReferenceFileHandle {
   def readAt(i: Long): Option[Char]
@@ -41,6 +51,10 @@ object ReferenceFileHandle {
   }
     
   final class InMemory(newStream: => InputStream) extends ReferenceFileHandle {
+    //Use a WeakReference to store the data in a reference file, so that it may be garbage-collected.
+    //Since most input files are broadly sorted by chromosome, this means it's likely that only one reference
+    //file will be needed at once.  Allowing the files' data to ge GC'd means that only hundreds of megs need
+    //stay on the heap at any time, instead of ~4GB.
     private var dataRef: WeakReference[Array[Byte]] = _
     
     private def dataOpt: Option[Array[Byte]] = Option(dataRef).flatMap(ref => Option(ref.get)) 
@@ -48,7 +62,7 @@ object ReferenceFileHandle {
     private def getData: Array[Byte] = dataOpt match {
       case Some(data) => data
       case None => {
-        val data = CanBeClosed.enclosed(newStream)(IOUtils.toByteArray)
+        val data: Array[Byte] = CanBeClosed.enclosed(newStream)(IOUtils.toByteArray)
         
         dataRef = new WeakReference(data)
         
@@ -62,6 +76,10 @@ object ReferenceFileHandle {
       require(i >= 0)
       
       withData { data =>
+        //Note i.toInt, since JVM array indices are ints :\
+        //Note .toChar, which assumes that the bytes loaded from the reference files represent characters convertible
+        //to JVM (unicode) chars.  (Ultimately this boils down to something like Numeric[Byte].toInt.toChar .)
+        //This is the same assumption (basically) as was made by the Perl code this is based on.
         if(i < data.length) { Some(data(i.toInt).toChar) }
         else { None }
       }

--- a/src/main/scala/loamstream/loam/intake/flip/ReferenceFiles.scala
+++ b/src/main/scala/loamstream/loam/intake/flip/ReferenceFiles.scala
@@ -2,21 +2,27 @@ package loamstream.loam.intake.flip
 
 import java.nio.file.Files.exists
 import java.nio.file.Path
+import loamstream.util.TimeUtils
+import loamstream.util.Loggable
 
 /**
  * @author clint
  * Apr 1, 2020
  */
-final class ReferenceFiles private[flip] (chromsToFiles: Map[String, ReferenceFileHandle]) {
+final class ReferenceFiles private[flip] (chromsToFiles: Map[String, ReferenceFileHandle]) extends Loggable {
   def isKnown(chrom: String): Boolean = chromsToFiles.contains(chrom)
   
-  def getChar(chrom: String, position: Long): Option[Char] = chromsToFiles.get(chrom).flatMap(_.readAt(position))
-  
-  def getString(chrom: String, position: Long, length: Int): Option[String] = {
-    chromsToFiles.get(chrom).flatMap(_.readAt(position, length))
+  def getChar(chrom: String, position: Long): Option[Char] = {
+    //TimeUtils.time(s"Getting char from chrom $chrom at pos $position", info(_)) {
+      chromsToFiles.get(chrom).flatMap(_.readAt(position))
+    //}
   }
   
-  def forChrom(chrom: String): ReferenceFileHandle = chromsToFiles(chrom)
+  def getString(chrom: String, position: Long, length: Int): Option[String] = {
+    //TimeUtils.time(s"Getting $length chars from chrom $chrom at pos $position", info(_)) {
+      chromsToFiles.get(chrom).flatMap(_.readAt(position, length))
+    //}
+  }
 }
   
 object ReferenceFiles {
@@ -39,8 +45,8 @@ object ReferenceFiles {
             s"ERROR: no sequence file for chromosome: ${chrom} (both ${txtPath} and ${gzPath} not found)")
         
         val handle = {
-          if(exists(txtPath)) { ReferenceFileHandle(txtPath.toFile) }
-          else { ReferenceFileHandle.fromGzippedFile(gzPath.toFile) }
+          if(exists(txtPath)) { ReferenceFileHandle(txtPath.toFile, inMemory = true) }
+          else { ReferenceFileHandle.fromGzippedFile(gzPath.toFile, inMemory = true) }
         }
         
         chrom -> handle

--- a/src/test/scala/loamstream/loam/intake/flip/ReferenceFileHandleTest.scala
+++ b/src/test/scala/loamstream/loam/intake/flip/ReferenceFileHandleTest.scala
@@ -18,47 +18,57 @@ final class ReferenceFileHandleTest extends FunSuite {
   
   test("readAt(i)") {
     withZippedAndUnzippedTestFiles("0123456789") { testFile =>
-      val handle = ReferenceFileHandle(testFile.toFile)
-      
-      intercept[Exception] {
-        handle.readAt(-100) === None
+      def doTest(inMemory: Boolean): Unit = {
+        val handle = ReferenceFileHandle(testFile.toFile, inMemory)
+        
+        intercept[Exception] {
+          handle.readAt(-100) === None
+        }
+        
+        intercept[Exception] {
+          handle.readAt(-1) === None
+        }
+        
+        assert(handle.readAt(0) === Some('0'))
+        assert(handle.readAt(5) === Some('5'))
+        assert(handle.readAt(1) === Some('1'))
+        assert(handle.readAt(9) === Some('9'))
+        
+        //EOF
+        assert(handle.readAt(10) === None) 
+        assert(handle.readAt(100) === None)
       }
       
-      intercept[Exception] {
-        handle.readAt(-1) === None
-      }
-      
-      assert(handle.readAt(0) === Some('0'))
-      assert(handle.readAt(5) === Some('5'))
-      assert(handle.readAt(1) === Some('1'))
-      assert(handle.readAt(9) === Some('9'))
-      
-      //EOF
-      assert(handle.readAt(10) === None) 
-      assert(handle.readAt(100) === None)
+      doTest(inMemory = false)
+      doTest(inMemory = true)
     }
   }
   
   test("readAt(i, length)") {
     withZippedAndUnzippedTestFiles("0123456789") { testFile =>
-      val handle = ReferenceFileHandle(testFile.toFile)
-      
-      intercept[Exception] {
-        handle.readAt(-100, 2) === None
+      def doTest(inMemory: Boolean): Unit = {
+        val handle = ReferenceFileHandle(testFile.toFile, inMemory)
+        
+        intercept[Exception] {
+          handle.readAt(-100, 2) === None
+        }
+        
+        intercept[Exception] {
+          handle.readAt(-1, 42) === None
+        }
+        
+        assert(handle.readAt(0, 1) === Some("0"))
+        assert(handle.readAt(5, 1) === Some("5"))
+        assert(handle.readAt(1, 1) === Some("1"))
+        assert(handle.readAt(9, 1) === Some("9"))
+        
+        //EOF
+        assert(handle.readAt(10, 1) === None) 
+        assert(handle.readAt(100) === None)
       }
       
-      intercept[Exception] {
-        handle.readAt(-1, 42) === None
-      }
-      
-      assert(handle.readAt(0, 1) === Some("0"))
-      assert(handle.readAt(5, 1) === Some("5"))
-      assert(handle.readAt(1, 1) === Some("1"))
-      assert(handle.readAt(9, 1) === Some("9"))
-      
-      //EOF
-      assert(handle.readAt(10, 1) === None) 
-      assert(handle.readAt(100) === None)
+      doTest(inMemory = false)
+      doTest(inMemory = true)
     }
   }
 }


### PR DESCRIPTION
- Cache reference files in memory, resulting in a speedup of a few hundred times when processing big files with the intake DSL.
- The new code makes the same assumptions as the old code, and Marcin's Perl scripts: that the reference files are big sequences of 1-byte chars where positions in the file correspond to positions in the reference genome.