### PR TITLE
Fixes for problems encountered during EBI data upload

### DIFF
--- a/src/main/scala/loamstream/compiler/LoamFile.scala
+++ b/src/main/scala/loamstream/compiler/LoamFile.scala
@@ -26,7 +26,7 @@ abstract class LoamFile extends LoamSyntax with LoamScript.LoamScriptBox {
     val context = LoamFile.ContextHolder.projectContext
     
     require(
-        context != null,
+        context != null, //scalastyle:ignore null
         s"No ${LoamProjectContext.getClass.getSimpleName} set.  Set it with ContextHolder.projectContext = ...")
     
     context
@@ -41,7 +41,9 @@ object LoamFile {
    * May 28, 2020
    */
   private[compiler] object ContextHolder {
-    private[this] val contextVar: DynamicVariable[LoamProjectContext] = new DynamicVariable(null)
+    private[this] val contextVar: DynamicVariable[LoamProjectContext] = {
+      new DynamicVariable(null) //scalastyle:ignore null
+    }
     
     def projectContext: LoamProjectContext = contextVar.value
     

--- a/src/main/scala/loamstream/loam/intake/aggregator/AggregatorCommands.scala
+++ b/src/main/scala/loamstream/loam/intake/aggregator/AggregatorCommands.scala
@@ -23,6 +23,7 @@ trait AggregatorCommands {
       csvFile: Store, 
       sourceColumnMapping: SourceColumns,
       workDir: Path = Paths.get("."),
+      skipValidation: Boolean = false,
       yes: Boolean = false)(implicit scriptContext: LoamScriptContext): Tool = {
     
     val aggregatorConfigFileName: Path = {
@@ -50,10 +51,11 @@ trait AggregatorCommands {
     
     val mainPyPart = s"${aggregatorIntakeScriptsRoot}/main.py"
     
-    
     val yesForcePart = if(yes) "--yes --force" else ""
       
-    cmd"""${aggregatorIntakeCondaEnvPart}python ${mainPyPart} variants ${yesForcePart} --skip-validation ${aggregatorConfigFile}""". // scalastyle:ignore line.size.limit
+    val skipValidationPart = if(skipValidation) "--skip-validation" else ""
+      
+    cmd"""${aggregatorIntakeCondaEnvPart}python ${mainPyPart} variants ${yesForcePart} ${skipValidationPart} ${aggregatorConfigFile}""". // scalastyle:ignore line.size.limit
         in(aggregatorConfigFile, csvFile)
   }
 }

--- a/src/main/scala/loamstream/loam/intake/aggregator/AggregatorCommands.scala
+++ b/src/main/scala/loamstream/loam/intake/aggregator/AggregatorCommands.scala
@@ -21,6 +21,7 @@ trait AggregatorCommands {
       aggregatorIntakeConfig: AggregatorIntakeConfig,
       metadata: Metadata, 
       csvFile: Store, 
+      sourceColumnMapping: SourceColumns,
       workDir: Path = Paths.get("."),
       yes: Boolean = false)(implicit scriptContext: LoamScriptContext): Tool = {
     
@@ -28,15 +29,7 @@ trait AggregatorCommands {
       workDir.resolve(s"aggregator-intake-${metadata.dataset}-${metadata.phenotype}.conf")
     }
     
-    val sourceColumns = SourceColumns(
-        marker = ColumnNames.marker,
-        pValue = ColumnNames.pvalue,
-        zScore = Some(ColumnNames.zscore),
-        stderr = Some(ColumnNames.stderr),
-        beta = Some(ColumnNames.beta),
-        eaf = Some(ColumnNames.eaf))
-            
-    val configData = ConfigData(metadata, sourceColumns, csvFile.path)      
+    val configData = ConfigData(metadata, sourceColumnMapping, csvFile.path)      
         
     val aggregatorConfigFile = store(aggregatorConfigFileName)
     

--- a/src/main/scala/loamstream/loam/intake/aggregator/ColumnDefs.scala
+++ b/src/main/scala/loamstream/loam/intake/aggregator/ColumnDefs.scala
@@ -56,7 +56,7 @@ object ColumnDefs {
   def eaf(sourceColumn: ColumnExpr[_], destColumn: ColumnName = ColumnNames.eaf): UnsourcedColumnDef = {
     val expr = asDouble(sourceColumn)
     
-    ColumnDef(destColumn, expr, expr.complement)
+    ColumnDef(destColumn, expr, 1.0 - expr)
   }
   
   //TODO: Something better, this makes potentially-superfluous .map() invocations

--- a/src/main/scala/loamstream/loam/intake/aggregator/Metadata.scala
+++ b/src/main/scala/loamstream/loam/intake/aggregator/Metadata.scala
@@ -64,7 +64,8 @@ object Metadata extends ConfigParser[Metadata] {
   def escape(s: String): String = {
     //flatMapping feels odd, but it works.  Figuring out the right combination of escapes in order to use 
     //String.replaceAll (which takes a regex as a Java/Scala string as its first arg, requiring its own escaping)
-    //was obviously possible, but not worth much frustration for such a small, relatively-infrequently-called method.    
+    //was obviously possible, but not worth the required frustration for such a small, 
+    //relatively-infrequently-called method.    
     def withQuotesEscaped = s.flatMap {
       case '\"' => "\\\""
       case c => c.toString

--- a/src/main/scala/loamstream/loam/intake/aggregator/SourceColumns.scala
+++ b/src/main/scala/loamstream/loam/intake/aggregator/SourceColumns.scala
@@ -4,8 +4,8 @@ import loamstream.loam.intake.ColumnName
 
 final case class SourceColumns(
     marker: ColumnName,
-    pValue: ColumnName,
-    zScore: Option[ColumnName] = None,
+    pvalue: ColumnName,
+    zscore: Option[ColumnName] = None,
     stderr: Option[ColumnName] = None,
     beta: Option[ColumnName] = None,
     oddsRatio: Option[ColumnName] = None,
@@ -14,15 +14,36 @@ final case class SourceColumns(
   
   validate()
   
+  def withoutZscore: SourceColumns = copy(zscore = None)
+  def withoutStderr: SourceColumns = copy(stderr = None)
+  def withoutBeta: SourceColumns = copy(beta = None)
+  def withoutOddsRatio: SourceColumns = copy(oddsRatio = None)
+  def withoutEaf: SourceColumns = copy(eaf = None)
+  def withoutMaf: SourceColumns = copy(maf = None)
+  
+  def withZscore(newZscore: ColumnName): SourceColumns = copy(zscore = Option(newZscore))
+  def withStderr(newStderr: ColumnName): SourceColumns = copy(stderr = Option(newStderr))
+  def withBeta(newBeta: ColumnName): SourceColumns = copy(beta = Option(newBeta))
+  def withOddsRatio(newOddsRatio: ColumnName): SourceColumns = copy(oddsRatio = Option(newOddsRatio))
+  def withEaf(newEaf: ColumnName): SourceColumns = copy(eaf = Option(newEaf))
+  def withMaf(newMaf: ColumnName): SourceColumns = copy(maf = Option(newMaf))
+  
+  def withDefaultZscore: SourceColumns = withZscore(ColumnNames.zscore)
+  def withDefaultStderr: SourceColumns = withStderr(ColumnNames.stderr)
+  def withDefaultBeta: SourceColumns = withBeta(ColumnNames.beta)
+  def withDefaultOddsRatio: SourceColumns = withOddsRatio(ColumnNames.odds_ratio)
+  def withDefaultEaf: SourceColumns = withEaf(ColumnNames.eaf)
+  def withDefaultMaf: SourceColumns = withMaf(ColumnNames.maf)
+  
   private val mapping: Map[ColumnName, ColumnName] = {
     //mandatory columns
     val mandatory = Map(
       ColumnNames.marker -> this.marker,
-      ColumnNames.pvalue -> this.pValue)
+      ColumnNames.pvalue -> this.pvalue)
       
     mandatory ++
       stderr.map(ColumnNames.stderr -> _) ++
-      zScore.map(ColumnNames.zscore -> _) ++
+      zscore.map(ColumnNames.zscore -> _) ++
       beta.map(ColumnNames.beta -> _) ++
       oddsRatio.map(ColumnNames.odds_ratio -> _) ++
       eaf.map(ColumnNames.eaf -> _) ++
@@ -54,9 +75,25 @@ final case class SourceColumns(
       require(beta.isDefined)
     }
     
-    if(zScore.isEmpty) {
+    if(zscore.isEmpty) {
       require(beta.isDefined)
       require(stderr.isDefined)
     }
+  }
+}
+
+object SourceColumns {
+  val defaultMarkerAndPvalueOnly: SourceColumns = {
+    SourceColumns(marker = ColumnNames.marker, pvalue = ColumnNames.pvalue)
+  }
+  
+  val allColumnsWithDefaultNames: SourceColumns = {
+    defaultMarkerAndPvalueOnly.copy(
+        zscore = Option(ColumnNames.zscore),
+        stderr = Option(ColumnNames.stderr),
+        beta = Option(ColumnNames.beta),
+        oddsRatio = Option(ColumnNames.odds_ratio),
+        eaf = Option(ColumnNames.eaf),
+        maf = Option(ColumnNames.maf))
   }
 }

--- a/src/main/scala/loamstream/loam/intake/aggregator/SourceColumns.scala
+++ b/src/main/scala/loamstream/loam/intake/aggregator/SourceColumns.scala
@@ -12,8 +12,6 @@ final case class SourceColumns(
     eaf: Option[ColumnName] = None,
     maf: Option[ColumnName] = None) {
   
-  validate()
-  
   def withoutZscore: SourceColumns = copy(zscore = None)
   def withoutStderr: SourceColumns = copy(stderr = None)
   def withoutBeta: SourceColumns = copy(beta = None)
@@ -58,26 +56,36 @@ final case class SourceColumns(
     aggregatorColumnNameToSourceColumnNameLines.mkString(System.lineSeparator)
   }
   
-  private def validate(): Unit = {
+  def validate(): Unit = {
     if(maf.isEmpty) {
-      require(eaf.isDefined)
+      require(eaf.isDefined, s"If ${ColumnNames.maf} column is not provided, then ${ColumnNames.eaf} must be.")
     }
     
     if(beta.isEmpty) {
-      require(oddsRatio.isDefined)
+      require(
+          oddsRatio.isDefined, 
+          s"If ${ColumnNames.beta} column is not provided, then ${ColumnNames.odds_ratio} must be.")
     }
     
     if(oddsRatio.isEmpty) {
-      require(beta.isDefined)
+      require(
+          beta.isDefined,
+          s"If ${ColumnNames.odds_ratio} column is not provided, then ${ColumnNames.beta} must be.")
     }
     
     if(stderr.isEmpty) {
-      require(beta.isDefined)
+      require(
+          beta.isDefined,
+          s"If ${ColumnNames.stderr} column is not provided, then ${ColumnNames.beta} must be.")
     }
     
     if(zscore.isEmpty) {
-      require(beta.isDefined)
-      require(stderr.isDefined)
+      def msg = {
+        s"If ${ColumnNames.zscore} column is not provided, then ${ColumnNames.beta} and ${ColumnNames.stderr} must be."
+      }
+      
+      require(beta.isDefined, msg)
+      require(stderr.isDefined, msg)
     }
   }
 }

--- a/src/main/scala/loamstream/loam/intake/rowDefs.scala
+++ b/src/main/scala/loamstream/loam/intake/rowDefs.scala
@@ -8,6 +8,12 @@ final case class RowDef(varIdDef: SourcedColumnDef, otherColumns: Seq[SourcedCol
   def columnDefs: Seq[SourcedColumnDef] = varIdDef +: otherColumns
 }
 
+object RowDef {
+  def apply(varIdDef: UnsourcedColumnDef, otherColumns: Seq[UnsourcedColumnDef]): UnsourcedRowDef = {
+    UnsourcedRowDef(varIdDef, otherColumns)
+  }
+}
+
 final case class UnsourcedRowDef(varIdDef: UnsourcedColumnDef, otherColumns: Seq[UnsourcedColumnDef]) {
   def from(source: CsvSource): RowDef = RowDef(varIdDef.from(source), otherColumns.map(_.from(source)))
 }

--- a/src/main/scala/loamstream/loam/intake/testing/UkbbDietaryGwas.scala
+++ b/src/main/scala/loamstream/loam/intake/testing/UkbbDietaryGwas.scala
@@ -9,6 +9,7 @@ import loamstream.loam.LoamScriptContext
 import loamstream.loam.intake.aggregator
 import loamstream.loam.intake.aggregator.AggregatorIntakeConfig
 import loamstream.loam.intake.aggregator.Metadata
+import loamstream.loam.intake.aggregator.SourceColumns
 
 /**
  * @author clint
@@ -147,8 +148,18 @@ object UkbbDietaryGwas extends loamstream.LoamFile {
     if(intakeTypesafeConfig.getBoolean("AGGREGATOR_INTAKE_DO_UPLOAD")) {
       val metadata = toMetadata(phenotype -> phenotypeConfig)
       
-      upload(aggregatorIntakePipelineConfig, metadata, dataInAggregatorFormat, workDir = Paths.workDir, yes = false).
-        tag(s"upload-to-s3-${phenotype}")
+      val sourceColumnMapping = SourceColumns.defaultMarkerAndPvalueOnly
+        .withDefaultZscore
+        .withDefaultStderr
+        .withDefaultBeta
+        .withDefaultEaf
+      
+      upload(
+          aggregatorIntakePipelineConfig, 
+          metadata, dataInAggregatorFormat, 
+          sourceColumnMapping, 
+          workDir = Paths.workDir, 
+          yes = false).tag(s"upload-to-s3-${phenotype}")
     }
   }
 }

--- a/src/test/scala/loamstream/loam/intake/aggregator/MetadataTest.scala
+++ b/src/test/scala/loamstream/loam/intake/aggregator/MetadataTest.scala
@@ -1,0 +1,21 @@
+package loamstream.loam.intake.aggregator
+
+import org.scalatest.FunSuite
+
+/**
+ * @author clint
+ * Jun 25, 2020
+ */
+final class MetadataTest extends FunSuite {
+  test("escape") {
+    import Metadata.escape
+    
+    assert(escape("") === "")
+    assert(escape("foo") === "foo")
+    assert(escape("foo bar") === "\"foo bar\"")
+    assert(escape(" ") === "\" \"")
+    
+    assert(escape("foo_\"lalala\"") === "foo_\"lalala\"")
+    assert(escape("foo \"lalala\"") === "\"foo \\\"lalala\\\"\"")
+  }
+}

--- a/src/test/scala/loamstream/loam/intake/examples/ReadMe.scala
+++ b/src/test/scala/loamstream/loam/intake/examples/ReadMe.scala
@@ -9,6 +9,7 @@ import loamstream.conf.LoamConfig
 import loamstream.loam.intake.aggregator.AggregatorCommands
 import loamstream.loam.intake.aggregator.AggregatorIntakeConfig
 import loamstream.loam.intake.aggregator.Metadata
+import loamstream.loam.intake.aggregator.SourceColumns
 
 /**
  * @author clint
@@ -126,7 +127,7 @@ object ReadMe extends AggregatorCommands {
   import ColumnNames._
   
   //Use aggregator-default column names to make things easier
-  val rowDef = UnsourcedRowDef(
+  val rowDef = RowDef(
       varIdDef = marker(CHR, BP, ALLELE0, ALLELE1),
       otherColumns = Seq(
         eaf(A1FREQ),
@@ -185,9 +186,17 @@ object ReadMe extends AggregatorCommands {
     
   val reallyProceed = false
   
+  val sourceColumnMapping = {
+    SourceColumns.defaultMarkerAndPvalueOnly
+      .withDefaultEaf  
+      .withDefaultBeta
+      .withDefaultStderr
+  }
+  
   upload(
       aggregatorIntakeConfig = aggregatorConfig,// aggregator-intake install dir, conda env name, etc 
       metadata = metadata, //Aggregator-specific metadata - dataset/phenotype name , num cases/controls, etc etc
       csvFile = transformedCsv,
+      sourceColumnMapping = sourceColumnMapping,
       yes = reallyProceed).tag("upload-to-S3")
 }

--- a/src/test/scala/loamstream/util/Base64Test.scala
+++ b/src/test/scala/loamstream/util/Base64Test.scala
@@ -14,7 +14,7 @@ final class Base64Test extends FunSuite {
   test("encode") {
     assert(encode(someBytes) === "Rk9PIGxhbGFsYQ==")
 
-	assert(encode(Array.empty) === "")
+    assert(encode(Array.empty) === "")
   }
 
   test("decode") {


### PR DESCRIPTION
- Parameterize on column mappings instead of hard-coding when invoking `dig-aggregator-intake`.
- Wrap strings in quotes if they contain whitespace when generating Aggregator config files.
- Don't always add `--skip-validation` when invoking `dig-aggregator-intake`.
- Minor improvements to Loam examples.