### PR TITLE
Intake DSL Improvements

### DIFF
--- a/src/main/scala/loamstream/drm/DrmChunkRunner.scala
+++ b/src/main/scala/loamstream/drm/DrmChunkRunner.scala
@@ -110,7 +110,13 @@ final case class DrmChunkRunner(
     drmTaskArray: DrmTaskArray): Observable[(LJob, RunData)] = {
 
     def submit(): Observable[DrmSubmissionResult] = {
-      TimeUtils.time(s"Submitting task array with ${drmTaskArray.size} jobs", debug(_)) {
+      val name = drmTaskArray.drmJobName
+      
+      val msg = s"Submitting task array ${name} with ${drmTaskArray.size} jobs"
+      
+      TimeUtils.time(msg, debug(_)) {
+        debug(msg)
+        
         jobSubmitter.submitJobs(drmSettings, drmTaskArray)
       }
     }

--- a/src/main/scala/loamstream/drm/DrmTaskArray.scala
+++ b/src/main/scala/loamstream/drm/DrmTaskArray.scala
@@ -46,6 +46,8 @@ final case class DrmTaskArray(
       
       val drmScriptInJobDir = jobDir.resolve("drm-script.sh")
       
+      debug(s"Copying script for task array ${drmJobName} to ${drmScriptInJobDir}")
+      
       LFiles.copyAndOverwrite(drmScript, drmScriptInJobDir)
     }
     

--- a/src/main/scala/loamstream/loam/intake/ColumnExpr.scala
+++ b/src/main/scala/loamstream/loam/intake/ColumnExpr.scala
@@ -200,6 +200,8 @@ final case class ColumnName(name: String) extends ColumnExpr[String] {
   }
   
   override def asString: ColumnExpr[String] = this
+  
+  def mapName(f: String => String): ColumnName = copy(name = f(name))
 }
 
 final case class MappedColumnExpr[A: TypeTag, B: TypeTag](f: A => B, dependsOn: ColumnExpr[A]) extends ColumnExpr[B] {

--- a/src/main/scala/loamstream/loam/intake/aggregator/AggregatorCommands.scala
+++ b/src/main/scala/loamstream/loam/intake/aggregator/AggregatorCommands.scala
@@ -22,11 +22,10 @@ trait AggregatorCommands {
       metadata: Metadata, 
       csvFile: Store, 
       sourceColumnMapping: SourceColumns,
+      workDir: Path = Paths.get("."),
       logFile: Option[Path] = None,
       skipValidation: Boolean = false,
       yes: Boolean = false)(implicit scriptContext: LoamScriptContext): Tool = {
-    
-    val workDir: Path = Paths.get(".")
     
     val aggregatorConfigFileName: Path = {
       workDir.resolve(s"aggregator-intake-${metadata.dataset}-${metadata.phenotype}.conf")

--- a/src/main/scala/loamstream/loam/intake/aggregator/AggregatorCommands.scala
+++ b/src/main/scala/loamstream/loam/intake/aggregator/AggregatorCommands.scala
@@ -22,10 +22,11 @@ trait AggregatorCommands {
       metadata: Metadata, 
       csvFile: Store, 
       sourceColumnMapping: SourceColumns,
-      workDir: Path = Paths.get("."),
       logFile: Option[Path] = None,
       skipValidation: Boolean = false,
       yes: Boolean = false)(implicit scriptContext: LoamScriptContext): Tool = {
+    
+    val workDir: Path = Paths.get(".")
     
     val aggregatorConfigFileName: Path = {
       workDir.resolve(s"aggregator-intake-${metadata.dataset}-${metadata.phenotype}.conf")

--- a/src/main/scala/loamstream/loam/intake/aggregator/AggregatorCommands.scala
+++ b/src/main/scala/loamstream/loam/intake/aggregator/AggregatorCommands.scala
@@ -23,6 +23,7 @@ trait AggregatorCommands {
       csvFile: Store, 
       sourceColumnMapping: SourceColumns,
       workDir: Path = Paths.get("."),
+      logFile: Option[Path] = None,
       skipValidation: Boolean = false,
       yes: Boolean = false)(implicit scriptContext: LoamScriptContext): Tool = {
     
@@ -55,7 +56,9 @@ trait AggregatorCommands {
       
     val skipValidationPart = if(skipValidation) "--skip-validation" else ""
       
-    cmd"""${aggregatorIntakeCondaEnvPart}python ${mainPyPart} variants ${yesForcePart} ${skipValidationPart} ${aggregatorConfigFile}""". // scalastyle:ignore line.size.limit
+    val logfilePart: String = logFile.map(lf => s"2>&1 | tee ${lf}").getOrElse("")
+      
+    cmd"""${aggregatorIntakeCondaEnvPart}python ${mainPyPart} variants ${yesForcePart} ${skipValidationPart} ${aggregatorConfigFile} ${logfilePart}""". // scalastyle:ignore line.size.limit
         in(aggregatorConfigFile, csvFile)
   }
 }

--- a/src/main/scala/loamstream/loam/intake/aggregator/ColumnDefs.scala
+++ b/src/main/scala/loamstream/loam/intake/aggregator/ColumnDefs.scala
@@ -36,21 +36,25 @@ object ColumnDefs {
     simpleDoubleColumn(sourceColumn, destColumn)
   }
   
-  def zscore(
+  def zscoreFrom(
       betaColumn: ColumnExpr[_], 
       stderrColumn: ColumnExpr[_], 
       destColumn: ColumnName = ColumnNames.zscore): UnsourcedColumnDef = {
     
     val expr = asDouble(betaColumn) / asDouble(stderrColumn)
     
-    ColumnDef(destColumn, expr, expr.negate)
+    negateIfFlipped(expr, destColumn)
+  }
+  
+  def zscore(
+      sourceColumn: ColumnExpr[_], 
+      destColumn: ColumnName = ColumnNames.zscore): UnsourcedColumnDef = {
+    
+    negateIfFlipped(sourceColumn, destColumn)
   }
   
   def beta(sourceColumn: ColumnExpr[_], destColumn: ColumnName = ColumnNames.beta): UnsourcedColumnDef = {
-    
-    val expr = asDouble(sourceColumn)
-    
-    ColumnDef(destColumn, expr, expr.negate)
+    negateIfFlipped(sourceColumn, destColumn)
   }
   
   def eaf(sourceColumn: ColumnExpr[_], destColumn: ColumnName = ColumnNames.eaf): UnsourcedColumnDef = {
@@ -59,10 +63,60 @@ object ColumnDefs {
     ColumnDef(destColumn, expr, 1.0 - expr)
   }
   
+  def oddsRatio(sourceColumn: ColumnExpr[_], destColumn: ColumnName = ColumnNames.odds_ratio): UnsourcedColumnDef = {
+    val expr = asDouble(sourceColumn)
+    
+    ColumnDef(destColumn, expr, 1.0 / expr)
+  }
+  
+  object PassThru {
+    def marker(sourceColumn: ColumnExpr[_], destColumn: ColumnName = ColumnNames.marker): UnsourcedColumnDef = {
+      ColumnDef(destColumn, sourceColumn)
+    }
+    
+    def pvalue(sourceColumn: ColumnExpr[_], destColumn: ColumnName = ColumnNames.pvalue): UnsourcedColumnDef = {
+      ColumnDef(destColumn, sourceColumn)
+    }
+    
+    def zscore(sourceColumn: ColumnExpr[_], destColumn: ColumnName = ColumnNames.zscore): UnsourcedColumnDef = {
+      ColumnDef(destColumn, sourceColumn)
+    }
+    
+    def stderr(sourceColumn: ColumnExpr[_], destColumn: ColumnName = ColumnNames.stderr): UnsourcedColumnDef = {
+      ColumnDef(destColumn, sourceColumn)
+    }
+    
+    def beta(sourceColumn: ColumnExpr[_], destColumn: ColumnName = ColumnNames.beta): UnsourcedColumnDef = {
+      ColumnDef(destColumn, sourceColumn)
+    }
+    
+    def oddsRatio(sourceColumn: ColumnExpr[_], destColumn: ColumnName = ColumnNames.odds_ratio): UnsourcedColumnDef = {
+      ColumnDef(destColumn, sourceColumn)
+    }
+    
+    def eaf(sourceColumn: ColumnExpr[_], destColumn: ColumnName = ColumnNames.eaf): UnsourcedColumnDef = {
+      ColumnDef(destColumn, sourceColumn)
+    }
+    
+    def maf(sourceColumn: ColumnExpr[_], destColumn: ColumnName = ColumnNames.maf): UnsourcedColumnDef = {
+      ColumnDef(destColumn, sourceColumn)
+    }
+    
+    def n(sourceColumn: ColumnExpr[_], destColumn: ColumnName = ColumnNames.stderr): UnsourcedColumnDef = {
+      ColumnDef(destColumn, sourceColumn)
+    }
+  }
+  
   //TODO: Something better, this makes potentially-superfluous .map() invocations
   private def asDouble(column: ColumnExpr[_]): ColumnExpr[Double] = column.asString.asDouble
       
   private def simpleDoubleColumn(
       sourceColumn: ColumnExpr[_],
       aggregatorName: ColumnName): UnsourcedColumnDef = ColumnDef(aggregatorName, asDouble(sourceColumn))
+      
+  def negateIfFlipped(sourceColumn: ColumnExpr[_], aggregatorName: ColumnName): UnsourcedColumnDef = {
+    val expr = asDouble(sourceColumn)
+    
+    ColumnDef(aggregatorName, expr, expr.negate)
+  }
 }

--- a/src/main/scala/loamstream/loam/intake/aggregator/ColumnDefs.scala
+++ b/src/main/scala/loamstream/loam/intake/aggregator/ColumnDefs.scala
@@ -102,7 +102,7 @@ object ColumnDefs {
       ColumnDef(destColumn, sourceColumn)
     }
     
-    def n(sourceColumn: ColumnExpr[_], destColumn: ColumnName = ColumnNames.stderr): UnsourcedColumnDef = {
+    def n(sourceColumn: ColumnExpr[_], destColumn: ColumnName = ColumnNames.n): UnsourcedColumnDef = {
       ColumnDef(destColumn, sourceColumn)
     }
   }

--- a/src/test/scala/loamstream/loam/intake/ColumnExprTest.scala
+++ b/src/test/scala/loamstream/loam/intake/ColumnExprTest.scala
@@ -455,4 +455,20 @@ final class ColumnExprTest extends FunSuite {
     assert(foo.isEmptyIgnoreWhitespace.apply(row) === true)
     assert(blerg.isEmptyIgnoreWhitespace.apply(row) === true)
   }
+  
+  test("mapName") {
+    val baz = ColumnName("baz")
+    
+    val BAZ = baz.mapName(_.toUpperCase)
+    
+    val row = Helpers.csvRow("bar" -> "42", "baz" -> "asdf  ", "foo" -> "", "blerg" -> "  ")
+    
+    assert(baz.name.toUpperCase === BAZ.name)
+    
+    assert(baz.eval(row) === "asdf  ")
+    
+    intercept[Exception] {
+      BAZ.eval(row)
+    }
+  }
 }

--- a/src/test/scala/loamstream/loam/intake/aggregator/ColumnDefsTest.scala
+++ b/src/test/scala/loamstream/loam/intake/aggregator/ColumnDefsTest.scala
@@ -1,0 +1,161 @@
+package loamstream.loam.intake.aggregator
+
+import org.scalatest.FunSuite
+import loamstream.loam.intake.ColumnDef
+import loamstream.loam.intake.ColumnName
+import loamstream.loam.intake.flip.FlipDetector
+import loamstream.loam.intake.Helpers
+
+/**
+ * @author clint
+ * Sep 28, 2020
+ */
+final class ColumnDefsTest extends FunSuite {
+  private val blarg = ColumnName("blarg")
+  
+  private object FlipDetectors {
+    val alwaysFlipped: FlipDetector = new FlipDetector {
+      override def isFlipped(variantId: String): Boolean = true
+    }
+    
+    val neverFlipped: FlipDetector = new FlipDetector {
+      override def isFlipped(variantId: String): Boolean = false
+    }
+  }
+  
+  private def assertCloseEnough(lhs: Double, rhs: Double, epsilon: Double = 0.000001): Unit = {
+    assert(math.abs(lhs - rhs) < epsilon)
+  }
+  
+  test("PassThru") {
+    def doTest(
+        f: ColumnName => ColumnDef,
+        expectedDestColumn: ColumnName): Unit = {
+  
+      val sourceColumn = ColumnName("blarg")
+      
+      assert(f(sourceColumn) === ColumnDef(expectedDestColumn, sourceColumn))
+    }
+    
+    import ColumnDefs.PassThru._
+    
+    doTest(beta(_), ColumnNames.beta)
+    doTest(eaf(_), ColumnNames.eaf)
+    doTest(maf(_), ColumnNames.maf)
+    doTest(marker(_), ColumnNames.marker)
+    doTest(n(_), ColumnNames.n)
+    doTest(oddsRatio(_), ColumnNames.odds_ratio)
+    doTest(pvalue(_), ColumnNames.pvalue)
+    doTest(stderr(_), ColumnNames.stderr)
+    doTest(zscore(_), ColumnNames.zscore)
+  }
+  
+  test("just") {
+    assert(ColumnDefs.just(blarg) === ColumnDef(blarg))
+  }
+  
+  test("marker") {
+    val foo = ColumnName("foo")
+    val bar = ColumnName("bar")
+    val baz = ColumnName("baz")
+    val bip = ColumnName("bip")
+    
+    val markerDef = ColumnDefs.marker(chromColumn = foo, posColumn = bar, refColumn = baz, altColumn = bip)
+    
+    assert(markerDef.name === ColumnNames.marker)
+    
+    val row = Helpers.csvRow("foo" -> "42", "bar" -> "asdf", "baz" -> "123", "bip" -> "456")
+    
+    assert(markerDef.getValueFromSource.apply(row) == "42_asdf_123_456") 
+    assert(markerDef.getValueFromSourceWhenFlipNeeded.get.apply(row) == "42_asdf_456_123")
+  }
+  
+  test("pvalue") {
+    val baz = ColumnName("baz")
+    
+    val pvalueDef = ColumnDefs.pvalue(baz)
+    
+    assert(pvalueDef.name === ColumnNames.pvalue)
+    
+    val row = Helpers.csvRow("foo" -> "42", "bar" -> "asdf", "baz" -> "1.23", "bip" -> "456")
+    
+    assert(pvalueDef.getValueFromSource.apply(row) == 1.23)
+  }
+  
+  test("stderr") {
+    val baz = ColumnName("baz")
+    
+    val stderrDef = ColumnDefs.stderr(baz)
+    
+    assert(stderrDef.name === ColumnNames.stderr)
+    
+    val row = Helpers.csvRow("foo" -> "42", "bar" -> "asdf", "baz" -> "1.23", "bip" -> "456")
+    
+    assert(stderrDef.getValueFromSource.apply(row) == 1.23)
+  }
+  
+  test("zscore") {
+    val baz = ColumnName("baz")
+    
+    val zscoreDef = ColumnDefs.zscore(baz)
+    
+    assert(zscoreDef.name === ColumnNames.zscore)
+    
+    val row = Helpers.csvRow("foo" -> "42", "bar" -> "asdf", "baz" -> "1.23", "bip" -> "456")
+    
+    assert(zscoreDef.getValueFromSource.apply(row) == 1.23)
+  }
+  
+  test("zscoreFrom") {
+    val baz = ColumnName("baz")
+    val bip = ColumnName("bip")
+    
+    val zscoreDef = ColumnDefs.zscoreFrom(betaColumn = baz, stderrColumn = bip)
+    
+    assert(zscoreDef.name === ColumnNames.zscore)
+    
+    val row = Helpers.csvRow("foo" -> "42", "bar" -> "asdf", "baz" -> "1.2", "bip" -> "6")
+    
+    assertCloseEnough(zscoreDef.getValueFromSource.apply(row).asInstanceOf[Double], 0.2)
+    assertCloseEnough(zscoreDef.getValueFromSourceWhenFlipNeeded.get.apply(row).asInstanceOf[Double], -0.2)
+  }
+  
+  test("beta") {
+    val baz = ColumnName("baz")
+    
+    val betaDef = ColumnDefs.beta(baz)
+    
+    assert(betaDef.name === ColumnNames.beta)
+    
+    val row = Helpers.csvRow("foo" -> "42", "bar" -> "asdf", "baz" -> "1.23", "bip" -> "456")
+    
+    assert(betaDef.getValueFromSource.apply(row) == 1.23)
+    assert(betaDef.getValueFromSourceWhenFlipNeeded.get.apply(row) == -1.23)
+  }
+
+  test("eaf") {
+    val baz = ColumnName("baz")
+    
+    val eafDef = ColumnDefs.eaf(baz)
+    
+    assert(eafDef.name === ColumnNames.eaf)
+    
+    val row = Helpers.csvRow("foo" -> "42", "bar" -> "asdf", "baz" -> "1.23", "bip" -> "456")
+    
+    assert(eafDef.getValueFromSource.apply(row) == 1.23)
+    assert(eafDef.getValueFromSourceWhenFlipNeeded.get.apply(row) == (1.0 - 1.23))
+  }
+  
+  test("oddsRatio") {
+    val baz = ColumnName("baz")
+    
+    val oddsRatioDef = ColumnDefs.oddsRatio(baz)
+    
+    assert(oddsRatioDef.name === ColumnNames.odds_ratio)
+    
+    val row = Helpers.csvRow("foo" -> "42", "bar" -> "asdf", "baz" -> "1.23", "bip" -> "456")
+    
+    assert(oddsRatioDef.getValueFromSource.apply(row) == 1.23)
+    assert(oddsRatioDef.getValueFromSourceWhenFlipNeeded.get.apply(row) == (1.0 / 1.23))
+  }
+}


### PR DESCRIPTION
Some things that came out of Ryan's last round of data-upload work:

- Allow passing a log file name to `AggregatorCommands.upload()` to make it easier to see output from `dig-aggregator-intake` while upload jobs are in-progress.  (Uger makes this inconvenient otherwise.)

- Add some more syntactic sugar to `aggregator.ColumnDefs`.

- Log locations of DRM shell scripts as they're copied to jobs' dirs at job-submission-time.
