### PR TITLE
Optional cases, controls, and subjects

### DIFF
--- a/src/main/scala/loamstream/loam/intake/aggregator/Metadata.scala
+++ b/src/main/scala/loamstream/loam/intake/aggregator/Metadata.scala
@@ -34,28 +34,19 @@ final case class Metadata(
     val authorPart = author.map(a => s"author ${escape(a)}").getOrElse("")
     
     import Metadata.Quantitative.CasesAndControls
+    import Metadata.Quantitative.Subjects
+    import System.lineSeparator
 
-    val casesPart = quantitative match {
-      case Some(CasesAndControls(cases, _)) => s"cases ${cases}"
-      case _ => ""
-    }
-    
-    val controlsPart = quantitative match {
-      case Some(CasesAndControls(_, controls)) => s"controls ${controls}"
-      case _ => ""
-    }
-    
-    val subjectsPart = subjects match {
-      case Some(s) => s"subjects ${s}"
+    val quantitativePart = quantitative match {
+      case Some(CasesAndControls(cases, controls)) => s"cases ${cases}${lineSeparator}controls ${controls}"
+      case Some(Subjects(s)) => s"subjects ${s}"
       case _ => ""
     }
     
     s"""|dataset ${dataset} ${phenotype}
         |ancestry ${escape(ancestry)}
         |tech ${escape(tech)}
-        |${casesPart}
-        |${controlsPart}
-        |${subjectsPart}
+        |${quantitativePart}
         |var_id ${varIdFormat}
         |${authorPart}""".stripMargin.trim
   }

--- a/src/main/scala/loamstream/loam/intake/aggregator/Metadata.scala
+++ b/src/main/scala/loamstream/loam/intake/aggregator/Metadata.scala
@@ -46,7 +46,7 @@ final case class Metadata(
     }
     
     val subjectsPart = subjects match {
-      case Some(s) => s"subjects ${subjects}"
+      case Some(s) => s"subjects ${s}"
       case _ => ""
     }
     

--- a/src/main/scala/loamstream/loam/intake/testing/UkbbDietaryGwas.scala
+++ b/src/main/scala/loamstream/loam/intake/testing/UkbbDietaryGwas.scala
@@ -123,7 +123,7 @@ object UkbbDietaryGwas extends loamstream.LoamFile {
   def toMetadata(phenotypeConfigTuple: (String, PhenotypeConfig)): Metadata = {
     val (phenotype, PhenotypeConfig(_, subjects)) = phenotypeConfigTuple
     
-    generalMetadata.toMetadata(phenotype, Metadata.Quantitative.Subjects(subjects))
+    generalMetadata.toMetadata(phenotype, Some(Metadata.Quantitative.Subjects(subjects)))
   }
   
   val flipDetector: FlipDetector = new FlipDetector.Default(

--- a/src/test/scala/loamstream/loam/intake/aggregator/MetadataTest.scala
+++ b/src/test/scala/loamstream/loam/intake/aggregator/MetadataTest.scala
@@ -18,4 +18,62 @@ final class MetadataTest extends FunSuite {
     assert(escape("foo_\"lalala\"") === "foo_\"lalala\"")
     assert(escape("foo \"lalala\"") === "\"foo \\\"lalala\\\"\"")
   }
+  
+  test("asConfigFileContents") {
+    import System.lineSeparator
+    
+    def doTest(
+        author: Option[String], 
+        expectedAuthorString: String,
+        quantitative: Option[Metadata.Quantitative], 
+        expectedQuantString: String): Unit = {
+
+      val dataset = "some-dataset"
+      val phenotype = "some-phenotype"
+      val varIdFormat = "{alt}_{ref}_{pos}_{chrom}"
+      val ancestry = "some ancestry"
+      val tech = "some tech"
+      val properties = Seq("x" -> "123", "a" -> "456")
+    
+      val m = Metadata(
+        dataset = dataset,
+        phenotype = phenotype,
+        varIdFormat = varIdFormat,
+        ancestry = ancestry,
+        author = author,
+        tech = tech,
+        quantitative = quantitative,
+        properties = properties)
+
+      val expected = s"""
+        |dataset ${dataset} ${phenotype}
+        |ancestry "${ancestry}"
+        |tech "${tech}"
+        |${expectedQuantString}
+        |var_id ${varIdFormat}
+        |${expectedAuthorString}""".stripMargin.trim
+    
+      def removeEmptyLines(s: String): String = {
+        s.split(lineSeparator).iterator.map(_.trim).filter(_.nonEmpty).mkString(lineSeparator)
+      }
+        
+      //NB: Ignore empty lines when considering differences
+      assert(removeEmptyLines(m.asConfigFileContents) === removeEmptyLines(expected))
+    }
+    
+    doTest(None, "", None, "")
+    doTest(Some("some-author"), "author some-author", None, "")
+    doTest(None, "", Some(Metadata.Quantitative.Subjects(42)), "subjects 42")
+    doTest(Some("some-author"), "author some-author", Some(Metadata.Quantitative.Subjects(42)), "subjects 42")
+    doTest(
+        None, 
+        "", 
+        Some(Metadata.Quantitative.CasesAndControls(42, 99)), 
+        s"cases 42${lineSeparator}controls 99")
+    doTest(
+        Some("some-author"), 
+        "author some-author",
+        Some(Metadata.Quantitative.CasesAndControls(42, 99)), 
+        s"cases 42${lineSeparator}controls 99")
+  }
 }

--- a/src/test/scala/loamstream/loam/intake/examples/ReadMe.scala
+++ b/src/test/scala/loamstream/loam/intake/examples/ReadMe.scala
@@ -177,8 +177,8 @@ object ReadMe extends AggregatorCommands {
     ancestry = "some-ancestry",
     author = Some("John Doe"),
     tech = "some-tech",
-    quantitative = Metadata.Quantitative.Subjects(42)
-    //or quantitative = Metadata.Quantitative.CasesAndControls(cases = 42, controls = 99)
+    quantitative = Some(Metadata.Quantitative.Subjects(42))
+    //or quantitative = Some(Metadata.Quantitative.CasesAndControls(cases = 42, controls = 99))
   )
   
   //NB: both aggregator.AggregatorIntakeConfigs and aggregator.Metadatas can be unmarshalled from HOCON .conf files.


### PR DESCRIPTION
To support recent Aggregator changes, make both cases/controls and subjects optional in Aggregator conf files.