### PR TITLE
Record Skipped Job Executions to Avoid Spurious Re-Runs

### DIFF
--- a/src/main/scala/loamstream/db/slick/CommandDaoOps.scala
+++ b/src/main/scala/loamstream/db/slick/CommandDaoOps.scala
@@ -1,7 +1,5 @@
 package loamstream.db.slick
 
-import loamstream.util.Loggable
-
 
 /**
  * @author clint
@@ -10,16 +8,11 @@ import loamstream.util.Loggable
 trait CommandDaoOps { self: CommonDaoOps with OutputDaoOps with ExecutionDaoOps =>
   import driver.api._
   
-  private object CommandDaoOpsLogger extends Loggable
-  
   override def findCommand(loc: String): Option[String] = {
     for {
       outputRow <- findOutputRow(loc)
-      _ = CommandDaoOpsLogger.trace(s"Looking up '$loc', found output row $outputRow")
       executionId <- outputRow.executionId
-      _ = CommandDaoOpsLogger.trace(s"Looking up '$loc', found execution id $executionId")
       executionRow <- findExecutionRow(executionId)
-      _ = CommandDaoOpsLogger.trace(s"Looking up '$loc', found execution row $executionRow")
       commandLine <- executionRow.cmd
     } yield commandLine
   }

--- a/src/main/scala/loamstream/db/slick/CommandDaoOps.scala
+++ b/src/main/scala/loamstream/db/slick/CommandDaoOps.scala
@@ -1,5 +1,8 @@
 package loamstream.db.slick
 
+import loamstream.util.Loggable
+
+
 /**
  * @author clint
  * Apr 22, 2020
@@ -7,11 +10,16 @@ package loamstream.db.slick
 trait CommandDaoOps { self: CommonDaoOps with OutputDaoOps with ExecutionDaoOps =>
   import driver.api._
   
+  private object CommandDaoOpsLogger extends Loggable
+  
   override def findCommand(loc: String): Option[String] = {
     for {
       outputRow <- findOutputRow(loc)
+      _ = CommandDaoOpsLogger.trace(s"Looking up '$loc', found output row $outputRow")
       executionId <- outputRow.executionId
+      _ = CommandDaoOpsLogger.trace(s"Looking up '$loc', found execution id $executionId")
       executionRow <- findExecutionRow(executionId)
+      _ = CommandDaoOpsLogger.trace(s"Looking up '$loc', found execution row $executionRow")
       commandLine <- executionRow.cmd
     } yield commandLine
   }

--- a/src/main/scala/loamstream/model/execute/DbBackedExecutionRecorder.scala
+++ b/src/main/scala/loamstream/model/execute/DbBackedExecutionRecorder.scala
@@ -13,11 +13,10 @@ import loamstream.model.jobs.JobOracle
 final class DbBackedExecutionRecorder(val dao: LoamDao) extends ExecutionRecorder {
   
   override def record(jobOracle: JobOracle, executionTuples: Iterable[(LJob, Execution)]): Unit = {
-    //NB: We can only insert command executions (UGER or command-line jobs, anything with an in exit status code)
-    //for now
-    def isInsertable(e: Execution): Boolean = e.isSkipped || e.isCommandExecution
+    //NB: We can only insert skipped executions and command executions (UGER or command-line jobs, 
+    //anything with an in exit status code) for now
     
-    val insertableExecutions = executionTuples.collect { case (_, e) if isInsertable(e) => e }
+    val insertableExecutions = executionTuples.collect { case (_, e) if e.isPersistable => e }
 
     dao.insertExecutions(insertableExecutions)
   }

--- a/src/main/scala/loamstream/model/execute/DbBackedExecutionRecorder.scala
+++ b/src/main/scala/loamstream/model/execute/DbBackedExecutionRecorder.scala
@@ -15,7 +15,9 @@ final class DbBackedExecutionRecorder(val dao: LoamDao) extends ExecutionRecorde
   override def record(jobOracle: JobOracle, executionTuples: Iterable[(LJob, Execution)]): Unit = {
     //NB: We can only insert command executions (UGER or command-line jobs, anything with an in exit status code)
     //for now
-    val insertableExecutions = executionTuples.collect { case (_, e) if e.isCommandExecution => e }
+    def isInsertable(e: Execution): Boolean = e.isSkipped || e.isCommandExecution
+    
+    val insertableExecutions = executionTuples.collect { case (_, e) if isInsertable(e) => e }
 
     dao.insertExecutions(insertableExecutions)
   }

--- a/src/main/scala/loamstream/model/execute/DbBackedJobFilter.scala
+++ b/src/main/scala/loamstream/model/execute/DbBackedJobFilter.scala
@@ -82,11 +82,23 @@ final class DbBackedJobFilter(
 
   private[execute] def hasNewCommandLine(job: LJob): Boolean = job match {
     case CommandLineJob.WithCommandLineAndOutputs(newCommandLine, outputs) if outputs.nonEmpty => {
-      val recordedCommandLine = findCommandLineInDb(outputs.head.location)
+      val firstOutputLocation = outputs.head.location
       
-      recordedCommandLine != Some(newCommandLine)
+      trace(s"Looking up job $job based on output ${firstOutputLocation}")
+      
+      val recordedCommandLine = findCommandLineInDb(firstOutputLocation)
+      
+      val result = recordedCommandLine != Some(newCommandLine)
+      
+      trace(s"For job $job, ${recordedCommandLine} != ${Some(newCommandLine)}? $result")
+      
+      result
     }
-    case _ => false
+    case _ => {
+      trace(s"Job $job is not a CommandLineJob; not determining if its command-line changed")
+      
+      false
+    }
   }
   
   private[execute] def lastFailureStatus(job: LJob): Option[JobStatus] = {

--- a/src/main/scala/loamstream/model/jobs/Execution.scala
+++ b/src/main/scala/loamstream/model/jobs/Execution.scala
@@ -42,6 +42,7 @@ final case class Execution(
       
   def isSuccess: Boolean = status.isSuccess
   def isFailure: Boolean = status.isFailure
+  def isSkipped: Boolean = status.isSkipped
   
   private def environmentAndResourcesMatch: Boolean = (envType, resources) match {
     case (_, None) => true
@@ -85,6 +86,13 @@ object Execution extends Loggable {
     def outputs: Set[StoreRecord]
     def jobDir: Option[Path]
     def terminationReason: Option[TerminationReason]
+  }
+  
+  object WithSkippedResult {
+    def unapply(e: Execution): Option[CommandResult] = e.status match {
+      case JobStatus.Skipped => Some(CommandResult(0))
+      case _ => None
+    }
   }
   
   object WithCommandResult {

--- a/src/test/scala/loamstream/model/execute/DbBackedExecutionRecorderTest.scala
+++ b/src/test/scala/loamstream/model/execute/DbBackedExecutionRecorderTest.scala
@@ -74,7 +74,7 @@ final class DbBackedExecutionRecorderTest extends FunSuite with ProvidesSlickLoa
             outputs = Set.empty[StoreRecord],
             terminationReason = None)
 
-        assert(e.isCommandExecution === false)
+        assert(e.isPersistable === false)
         
         recorder.record(TestHelpers.DummyJobOracle, Seq(job -> e))
   


### PR DESCRIPTION
A previous PR added the `Runs` table to the DB, and made LS delete info about the oldest `Run` on startup.  This has been successful at keeping the size of the DB in check, but made it possible for info about jobs to "age out" of the DB.  This happened because info about skipped jobs wasn't recorded, so running the same pipeline multiple times would result in a normal run of all jobs the first time, all jobs being skipped the next N times, and then all jobs being re-run once info from the first, successful run "aged out" of the DB.

This PR makes LS record info about skipped jobs.  Info still "ages out" of the DB, but this no longer results in info about existing job outputs being deleted, leading to job re-runs.