### PR TITLE
Add needed Hailctl and Singularity params

### DIFF
--- a/src/main/scala/loamstream/compiler/LoamPredef.scala
+++ b/src/main/scala/loamstream/compiler/LoamPredef.scala
@@ -128,7 +128,7 @@ trait LoamPredef extends Loggable {
     val runInContainer = imageName.nonEmpty
     
     val containerParamsOpt: Option[ContainerParams] = {
-      if(runInContainer) { Some(ContainerParams(imageName)) } 
+      if(runInContainer) { Some(ContainerParams(imageName, loamConfig.executionConfig.singularity.extraParams)) } 
       else { None }
     }
     

--- a/src/main/scala/loamstream/conf/SingularityConfig.scala
+++ b/src/main/scala/loamstream/conf/SingularityConfig.scala
@@ -11,7 +11,8 @@ import SingularityConfig.Defaults
  */
 final case class SingularityConfig(
     executable: String = Defaults.executable,
-    mappedDirs: Seq[Path] = Defaults.mappedDirs)
+    mappedDirs: Seq[Path] = Defaults.mappedDirs,
+    extraParams: String = Defaults.extraParams)
 
 object SingularityConfig extends ConfigParser[SingularityConfig] {
   
@@ -21,6 +22,8 @@ object SingularityConfig extends ConfigParser[SingularityConfig] {
     val executable: String = "singularity"
     
     val mappedDirs: Seq[Path] = Nil
+    
+    val extraParams: String = ""
   }
   
   override def fromConfig(config: Config): Try[SingularityConfig] = {

--- a/src/main/scala/loamstream/drm/ContainerParams.scala
+++ b/src/main/scala/loamstream/drm/ContainerParams.scala
@@ -8,4 +8,4 @@ import java.nio.file.Path
  * 
  * Represents the information needed to run commands in a Singularity container. 
  */
-final case class ContainerParams(imageName: String)
+final case class ContainerParams(imageName: String, extraParams: String)

--- a/src/main/scala/loamstream/drm/DrmJobWrapper.scala
+++ b/src/main/scala/loamstream/drm/DrmJobWrapper.scala
@@ -48,9 +48,13 @@ final case class DrmJobWrapper(
       }.mkString
     }
 
+    def munge(extraParams: String): String = if(extraParams.nonEmpty) s"${extraParams} " else extraParams
+    
     val singularityPart = drmSettings.containerParams match {
-      case Some(params) => s"${singularityConfig.executable} exec ${mappingPart}${params.imageName} "
-      case _            => ""
+      case Some(ContainerParams(imageName, extraParams)) => {
+        s"${singularityConfig.executable} exec ${mappingPart}${munge(extraParams)}${imageName} "
+      }
+      case _ => ""
     }
 
     val result = s"${singularityPart}${commandLineJob.commandLineString}"

--- a/src/main/scala/loamstream/googlecloud/CloudSdkDataProcWrapper.scala
+++ b/src/main/scala/loamstream/googlecloud/CloudSdkDataProcWrapper.scala
@@ -65,7 +65,8 @@ object CloudSdkDataProcWrapper extends Loggable {
   private[googlecloud] def gcloudTokens(config: GoogleCloudConfig)(verb: String)(args: String*): Seq[String] = {
     val gcloud = normalize(config.gcloudBinary)
 
-    gcloud +: "beta" +: "dataproc" +: "clusters" +: verb +: "--project" +: config.projectId +: "--region" +: config.region +: args
+    gcloud +: "beta" +: "dataproc" +: "clusters" +: verb +: "--project" +: config.projectId +: 
+    "--region" +: config.region +: args
   }
 
   private def runCommand(tokens: Seq[String]): Int = runProcess(tokens.mkString(" "), "Google Cloud SDK")

--- a/src/main/scala/loamstream/googlecloud/CloudSdkDataProcWrapper.scala
+++ b/src/main/scala/loamstream/googlecloud/CloudSdkDataProcWrapper.scala
@@ -65,7 +65,7 @@ object CloudSdkDataProcWrapper extends Loggable {
   private[googlecloud] def gcloudTokens(config: GoogleCloudConfig)(verb: String)(args: String*): Seq[String] = {
     val gcloud = normalize(config.gcloudBinary)
 
-    gcloud +: "beta" +: "dataproc" +: "clusters" +: verb +: "--project" +: config.projectId +: args
+    gcloud +: "beta" +: "dataproc" +: "clusters" +: verb +: "--project" +: config.projectId +: "--region" +: config.region +: args
   }
 
   private def runCommand(tokens: Seq[String]): Int = runProcess(tokens.mkString(" "), "Google Cloud SDK")

--- a/src/main/scala/loamstream/googlecloud/ClusterConfig.scala
+++ b/src/main/scala/loamstream/googlecloud/ClusterConfig.scala
@@ -7,7 +7,6 @@ import ClusterConfig.Defaults
  * Jul 11, 2019
  */
 final case class ClusterConfig(
-    region: String = Defaults.region,
     zone: String = Defaults.zone,
     masterMachineType: String = Defaults.masterMachineType,
     masterBootDiskSize: Int = Defaults.masterBootDiskSize,
@@ -24,7 +23,6 @@ object ClusterConfig {
   val default: ClusterConfig = ClusterConfig()
   
   object Defaults { // for creating a minimal cluster
-    val region: String = "us-central1"
     val zone: String = "us-central1-b"
     val masterMachineType: String = "n1-standard-1"
     val masterBootDiskSize: Int = 20 // in GB

--- a/src/main/scala/loamstream/googlecloud/ClusterConfig.scala
+++ b/src/main/scala/loamstream/googlecloud/ClusterConfig.scala
@@ -7,6 +7,7 @@ import ClusterConfig.Defaults
  * Jul 11, 2019
  */
 final case class ClusterConfig(
+    region: String = Defaults.region,
     zone: String = Defaults.zone,
     masterMachineType: String = Defaults.masterMachineType,
     masterBootDiskSize: Int = Defaults.masterBootDiskSize,
@@ -23,6 +24,7 @@ object ClusterConfig {
   val default: ClusterConfig = ClusterConfig()
   
   object Defaults { // for creating a minimal cluster
+    val region: String = "us-central1"
     val zone: String = "us-central1-b"
     val masterMachineType: String = "n1-standard-1"
     val masterBootDiskSize: Int = 20 // in GB

--- a/src/main/scala/loamstream/googlecloud/GoogleCloudConfig.scala
+++ b/src/main/scala/loamstream/googlecloud/GoogleCloudConfig.scala
@@ -27,6 +27,7 @@ final case class GoogleCloudConfig(
     projectId: String,
     clusterId: String,
     credentialsFile: Path,
+    region: String,
     defaultClusterConfig: ClusterConfig = Defaults.clusterConfig)
 
 object GoogleCloudConfig extends Loggable {
@@ -40,6 +41,7 @@ object GoogleCloudConfig extends Loggable {
       projectId: String,
       clusterId: String,
       credentialsFile: Path,
+      region: String,
       defaultClusterConfig: ClusterConfig = Defaults.clusterConfig) {
     
     def toGoogleCloudConfig: Try[GoogleCloudConfig] = {
@@ -52,6 +54,7 @@ object GoogleCloudConfig extends Loggable {
           projectId = projectId,
           clusterId = clusterId,
           credentialsFile = credentialsFile,
+          region = region,
           defaultClusterConfig = defaultClusterConfig)
       }
     }

--- a/src/main/scala/loamstream/googlecloud/HailCtlDataProcClient.scala
+++ b/src/main/scala/loamstream/googlecloud/HailCtlDataProcClient.scala
@@ -54,6 +54,8 @@ object HailCtlDataProcClient extends Loggable {
     val tokens: Seq[String] = Seq(
       "--project",
       googleConfig.projectId,
+      "--region",
+      clusterConfig.region,
       "--zone",
       clusterConfig.zone,
       "--master-machine-type",

--- a/src/main/scala/loamstream/googlecloud/HailCtlDataProcClient.scala
+++ b/src/main/scala/loamstream/googlecloud/HailCtlDataProcClient.scala
@@ -55,7 +55,7 @@ object HailCtlDataProcClient extends Loggable {
       "--project",
       googleConfig.projectId,
       "--region",
-      clusterConfig.region,
+      googleConfig.region,
       "--zone",
       clusterConfig.zone,
       "--master-machine-type",
@@ -94,6 +94,7 @@ object HailCtlDataProcClient extends Loggable {
                                  |conda activate ${hailConfig.condaEnv}
                                  |PATH="${normalize(googleConfig.gcloudBinary.getParent)}":$${PATH}
                                  |CLOUDSDK_CORE_PROJECT="${googleConfig.projectId}"
+                                 |CLOUDSDK_DATAPROC_REGION="${googleConfig.region}"
                                  |${command}""".stripMargin
 
     CloudSdkDataProcWrapper.runProcess(fullScriptContents, "hailctl")

--- a/src/main/scala/loamstream/googlecloud/HailLoamSyntax.scala
+++ b/src/main/scala/loamstream/googlecloud/HailLoamSyntax.scala
@@ -77,7 +77,9 @@ trait HailLoamSyntax {
         val regionEnvVarPart = s"""export CLOUDSDK_DATAPROC_REGION="${googleConfig.region}""""
         val pathMungingPart = s"""export PATH="${normalize(googleConfig.gcloudBinary.getParent)}":$${PATH}"""
     
-        val prefix = s"${sourceBashrcPart} && ${activateCondaPart} && ${projectIdEnvVarPart} && ${regionEnvVarPart} && ${pathMungingPart}"
+        val envVarsPart = s"${projectIdEnvVarPart} && ${regionEnvVarPart} && ${pathMungingPart}"
+        
+        val prefix = s"${sourceBashrcPart} && ${activateCondaPart} && ${envVarsPart}"
         
         s"""${prefix} && hailctl dataproc submit ${googleConfig.clusterId} """
       }

--- a/src/main/scala/loamstream/googlecloud/HailLoamSyntax.scala
+++ b/src/main/scala/loamstream/googlecloud/HailLoamSyntax.scala
@@ -74,9 +74,10 @@ trait HailLoamSyntax {
         val sourceBashrcPart = "source ~/.bashrc"
         val activateCondaPart = s"""conda activate "${hailConfig.condaEnv}""""
         val projectIdEnvVarPart = s"""export CLOUDSDK_CORE_PROJECT="${googleConfig.projectId}""""
+        val regionEnvVarPart = s"""export CLOUDSDK_DATAPROC_REGION="${googleConfig.region}""""
         val pathMungingPart = s"""export PATH="${normalize(googleConfig.gcloudBinary.getParent)}":$${PATH}"""
     
-        val prefix = s"${sourceBashrcPart} && ${activateCondaPart} && ${projectIdEnvVarPart} && ${pathMungingPart}"
+        val prefix = s"${sourceBashrcPart} && ${activateCondaPart} && ${projectIdEnvVarPart} && ${regionEnvVarPart} && ${pathMungingPart}"
         
         s"""${prefix} && hailctl dataproc submit ${googleConfig.clusterId} """
       }

--- a/src/test/resources/loamstream-test.conf
+++ b/src/test/resources/loamstream-test.conf
@@ -26,6 +26,7 @@ loamstream {
     projectId = "some-project"
     clusterId = "some-cluster"
     credentialsFile = "/path/to/google_credential.json"
+    region = "some-region"
     
     hail {
       jar = "gs://loamstream/path/to/hail-hail-is-master-all-spark2.0.2.jar"

--- a/src/test/scala/loamstream/UgerConfigIsPropagatedToJobsTest.scala
+++ b/src/test/scala/loamstream/UgerConfigIsPropagatedToJobsTest.scala
@@ -61,7 +61,7 @@ final class UgerConfigIsPropagatedToJobsTest extends FunSuite {
           Memory.inGb(16), 
           CpuTime.inHours(5), 
           expectedQueue, 
-          Some(ContainerParams("library/foo:1.2.3")))
+          Some(ContainerParams("library/foo:1.2.3", "")))
       
       assert(jobs.head.initialSettings === expectedSettings)
     }

--- a/src/test/scala/loamstream/compiler/LoamPredefTest.scala
+++ b/src/test/scala/loamstream/compiler/LoamPredefTest.scala
@@ -24,6 +24,7 @@ import loamstream.model.execute.Settings
 import loamstream.model.execute.LocalSettings
 import loamstream.googlecloud.ClusterConfig
 import loamstream.conf.LsSettings
+import loamstream.conf.SingularityConfig
 
 /**
  * @author clint
@@ -149,7 +150,7 @@ final class LoamPredefTest extends FunSuite {
           Memory.inGb(4), 
           CpuTime.inHours(6), 
           drmSystem.defaultQueue, //use this default, since it's not possible to specify a queue via drmWith()
-          Some(ContainerParams(imageName = "library/foo:1.2.3")))
+          Some(ContainerParams(imageName = "library/foo:1.2.3", SingularityConfig.default.extraParams)))
       
       doSettingsTest(
           scriptContext, 

--- a/src/test/scala/loamstream/conf/SingularityConfigTest.scala
+++ b/src/test/scala/loamstream/conf/SingularityConfigTest.scala
@@ -1,0 +1,54 @@
+package loamstream.conf
+
+import org.scalatest.FunSuite
+import com.typesafe.config.ConfigFactory
+import scala.util.Try
+import loamstream.TestHelpers
+
+/**
+ * @author clint
+ * Jan 22, 2021
+ */
+final class SingularityConfigTest extends FunSuite {
+  test("Defaults") {
+    assert(SingularityConfig.default.executable === "singularity")
+    assert(SingularityConfig.default.mappedDirs.isEmpty)
+    assert(SingularityConfig.default.extraParams.isEmpty)
+  }
+  
+  test("Empty HOCON") {
+    def conf(input: String) = SingularityConfig.fromConfig(ConfigFactory.parseString(input)).get
+    
+    assert(conf("") === SingularityConfig.default)
+    assert(conf("{}") === SingularityConfig.default)
+  }
+  
+  test("Bad input") {
+    def conf(input: String) = Try(ConfigFactory.parseString(input)).flatMap(SingularityConfig.fromConfig)
+    
+    assert(conf("asdasdasd").isFailure)
+    assert(conf("{").isFailure)
+  }
+  
+  test("Good input") {
+    val input = """
+loamstream {
+  execution {
+    singularity {
+      executable = /foo/bar/blerg
+      mappedDirs = [x, y, /bar/baz]
+      extraParams = "--foo --bar 42"
+    }
+  }
+}
+"""
+    
+    val conf = SingularityConfig.fromConfig(ConfigFactory.parseString(input)).get
+    
+    import TestHelpers.path
+    
+    assert(conf.executable === "/foo/bar/blerg")
+    assert(conf.mappedDirs === Seq(path("x"), path("y"), path("/bar/baz")))
+    assert(conf.extraParams === "--foo --bar 42")
+  }
+}

--- a/src/test/scala/loamstream/db/slick/SlickLoamDaoTest.scala
+++ b/src/test/scala/loamstream/db/slick/SlickLoamDaoTest.scala
@@ -371,7 +371,7 @@ final class SlickLoamDaoTest extends FunSuite with ProvidesSlickLoamDao with Pro
           Memory.inGb(4), 
           LsfDefaults.maxRunTime, 
           None,
-          Some(ContainerParams(imageName = "library/foo:1.2.3")))
+          Some(ContainerParams(imageName = "library/foo:1.2.3", "")))
               
       val googleSettings = GoogleSettings("some-cluster", ClusterConfig.default)
 
@@ -628,14 +628,14 @@ final class SlickLoamDaoTest extends FunSuite with ProvidesSlickLoamDao with Pro
         Memory.inGb(4), 
         UgerDefaults.maxRunTime, 
         Option(UgerDefaults.queue), 
-        Some(ContainerParams(imageName = "library/foo:1.2.3")))
+        Some(ContainerParams(imageName = "library/foo:1.2.3", "")))
 
     val lsfSettings = LsfDrmSettings(
         Cpus(8), 
         Memory.inGb(4), 
         LsfDefaults.maxRunTime, 
         None, 
-        Some(ContainerParams(imageName = "library/foo:1.2.3")))
+        Some(ContainerParams(imageName = "library/foo:1.2.3", "")))
         
     val googleSettings = GoogleSettings("some-cluster", ClusterConfig.default)
 

--- a/src/test/scala/loamstream/drm/ScriptBuilderTest.scala
+++ b/src/test/scala/loamstream/drm/ScriptBuilderTest.scala
@@ -83,7 +83,7 @@ final class ScriptBuilderTest extends FunSuite {
       assert(scriptContents === expectedScriptContents)
     }
     
-    val containerParams = ContainerParams("library/foo:1.23")
+    val containerParams = ContainerParams("library/foo:1.23", "--foo --bar")
     
     doTest(DrmSystem.Uger, None)
     doTest(DrmSystem.Uger, Some(containerParams))
@@ -193,7 +193,8 @@ final class ScriptBuilderTest extends FunSuite {
     val sixSpaces = "      "
 
     val singularityPrefix: String = containerParamsOpt match {
-      case Some(containerParams) => s"singularity exec ${containerParams.imageName} "
+      case Some(ContainerParams(imageName, "")) => s"singularity exec ${imageName} "
+      case Some(ContainerParams(imageName, params)) => s"singularity exec $params ${imageName} "
       case _ => ""
     }
     

--- a/src/test/scala/loamstream/drm/lsf/BsubJobSubmitterTest.scala
+++ b/src/test/scala/loamstream/drm/lsf/BsubJobSubmitterTest.scala
@@ -162,7 +162,7 @@ final class BsubJobSubmitterTest extends FunSuite {
       memoryPerCore = Memory.inGb(7),
       maxRunTime = CpuTime.inHours(3),
       queue = Some(queue),
-      containerParams = Some(ContainerParams(imageName = "library/foo:1.2.3")))
+      containerParams = Some(ContainerParams(imageName = "library/foo:1.2.3", "")))
   
   private lazy val settingsWithoutContainer = settings.copy(containerParams = None)
           

--- a/src/test/scala/loamstream/drm/uger/QsubTest.scala
+++ b/src/test/scala/loamstream/drm/uger/QsubTest.scala
@@ -49,7 +49,7 @@ final class QsubTest extends FunSuite {
     }
 
     doTest(None, Nil)
-    doTest(Some(ContainerParams("docker://library/foo:1.2.3")), Seq("-l", "os=RedHat7"))
+    doTest(Some(ContainerParams("docker://library/foo:1.2.3", "")), Seq("-l", "os=RedHat7"))
   }
   
   private def doTestWithDefaultJobSubmissionParams(

--- a/src/test/scala/loamstream/googlecloud/CloudSdkDataProcWrapperTest.scala
+++ b/src/test/scala/loamstream/googlecloud/CloudSdkDataProcWrapperTest.scala
@@ -21,6 +21,7 @@ final class CloudSdkDataProcWrapperTest extends FunSuite {
     projectId = "pid",
     clusterId = "cid",
     credentialsFile = path("N/A"),
+    region = "rid",
     //non-default values
     defaultClusterConfig = ClusterConfig(
       numWorkers = 42,
@@ -73,7 +74,17 @@ final class CloudSdkDataProcWrapperTest extends FunSuite {
     val tokens = gcloudTokens(config)("foo")("--bar", "Baz")
 
     val expectedTokens = {
-      Seq(examplePath.render, "beta", "dataproc", "clusters", "foo", "--project", config.projectId, "--bar", "Baz")
+      Seq(examplePath.render, 
+          "beta", 
+          "dataproc", 
+          "clusters", 
+          "foo", 
+          "--project", 
+          config.projectId, 
+          "--region",
+          config.region,
+          "--bar", 
+          "Baz")
     }
     
     assert(tokens === expectedTokens)
@@ -91,7 +102,9 @@ final class CloudSdkDataProcWrapperTest extends FunSuite {
         "clusters", 
         "describe", 
         "--project", 
-        config.projectId, 
+        config.projectId,
+        "--region",
+        config.region,
         config.clusterId)
     
     assert(tokens === expectedTokens)
@@ -109,7 +122,9 @@ final class CloudSdkDataProcWrapperTest extends FunSuite {
         "clusters", 
         "delete", 
         "--project", 
-        config.projectId, 
+        config.projectId,
+        "--region",
+        config.region,
         config.clusterId) 
     
     assert(tokens === expectedTokens)

--- a/src/test/scala/loamstream/googlecloud/GoogleCloudChunkRunnerTest.scala
+++ b/src/test/scala/loamstream/googlecloud/GoogleCloudChunkRunnerTest.scala
@@ -43,7 +43,7 @@ final class GoogleCloudChunkRunnerTest extends FunSuite with ProvidesEnvAndResou
   private val googleConfig = {
     import TestHelpers.path
     
-    GoogleCloudConfig(path("gcloud"), path("gsutil"), "some-project-id", clusterId, path("creds-file"))
+    GoogleCloudConfig(path("gcloud"), path("gsutil"), "some-project-id", clusterId, path("creds-file"), "some-region")
   }
 
   private val clusterConfig0 = ClusterConfig.default.copy(zone = "foo")

--- a/src/test/scala/loamstream/googlecloud/GoogleCloudConfigTest.scala
+++ b/src/test/scala/loamstream/googlecloud/GoogleCloudConfigTest.scala
@@ -31,6 +31,7 @@ final class GoogleCloudConfigTest extends FunSuite {
   private val workerBootDiskSize = 17
   private val properties = "p,r,o,p,s"
   private val maxClusterIdleTime = "42h"
+  private val region = "region-askdhasf"
 
   test("fromConfig - defaults used") {
     val confString = s"""loamstream {
@@ -40,6 +41,7 @@ final class GoogleCloudConfigTest extends FunSuite {
           projectId = "$projectId"
           clusterId = "$clusterId"
           credentialsFile = "$credentialsFile"
+          region = "${region}"
         }
       }"""
 
@@ -52,6 +54,7 @@ final class GoogleCloudConfigTest extends FunSuite {
     assert(gConfig.projectId === projectId)
     assert(gConfig.clusterId === clusterId)
     assert(gConfig.credentialsFile === Paths.get(credentialsFile))
+    assert(gConfig.region === region)
 
     import GoogleCloudConfig.Defaults
 
@@ -82,6 +85,7 @@ final class GoogleCloudConfigTest extends FunSuite {
           projectId = "$projectId"
           clusterId = "$clusterId"
           credentialsFile = "$credentialsFile"
+          region = "${region}"
           defaultClusterConfig {
             numWorkers = $numWorkers
             zone = "$zone"
@@ -106,6 +110,8 @@ final class GoogleCloudConfigTest extends FunSuite {
     assert(gConfig.gsutilBinary === Paths.get(gsutilBinaryPath))
     assert(gConfig.projectId === projectId)
     assert(gConfig.clusterId === clusterId)
+    assert(gConfig.credentialsFile === Paths.get(credentialsFile))
+    assert(gConfig.region === region)
     assert(gConfig.defaultClusterConfig.numWorkers === numWorkers)
     assert(gConfig.defaultClusterConfig.zone === zone)
     assert(gConfig.defaultClusterConfig.masterMachineType === masterMachineType)

--- a/src/test/scala/loamstream/googlecloud/HailCtlDataProcClientTest.scala
+++ b/src/test/scala/loamstream/googlecloud/HailCtlDataProcClientTest.scala
@@ -71,6 +71,7 @@ final class HailCtlDataProcClientTest extends FunSuite {
         projectId = "some-project-id",
         clusterId = "some-cluster-id",
         credentialsFile = path("some/creds/file"),
+        region = "some-region",
         defaultClusterConfig = clusterConfig)
     
     val expected = Seq(
@@ -79,6 +80,8 @@ final class HailCtlDataProcClientTest extends FunSuite {
       "start",
       "--project",
       googleConfig.projectId,
+      "--region", 
+      googleConfig.region,
       "--zone",
       clusterConfig.zone,
       "--master-machine-type",

--- a/src/test/scala/loamstream/googlecloud/HailSupportTest.scala
+++ b/src/test/scala/loamstream/googlecloud/HailSupportTest.scala
@@ -31,6 +31,7 @@ final class HailSupportTest extends FunSuite {
 
   private val clusterId = "cluster-asdfasdf"
   private val projectId = "project-kajsdhka"
+  private val region = "region-kasdhasfd"
   
   //NB: Write pyhail script files to a temp dir
   private lazy val config: LoamConfig = {
@@ -43,6 +44,7 @@ final class HailSupportTest extends FunSuite {
           projectId = "${projectId}"
           clusterId = "${clusterId}"
           credentialsFile = "/path/to/creds"
+          region = "${region}"
 
           hail {
             condaEnv = "hail-0.2.18"
@@ -62,15 +64,13 @@ final class HailSupportTest extends FunSuite {
   // scalastyle:off line.size.limit
   private val sep = File.separator
   private val gCloudPath = s"${sep}path${sep}to${sep}gcloud"
-  private val hailctlPrefix = s"""source ~/.bashrc && conda activate "hail-0.2.18" && export CLOUDSDK_CORE_PROJECT="${projectId}" && export PATH="/path/to":$${PATH} && hailctl dataproc submit ${clusterId} """
+  private val hailctlPrefix = s"""source ~/.bashrc && conda activate "hail-0.2.18" && export CLOUDSDK_CORE_PROJECT="${projectId}" && export CLOUDSDK_DATAPROC_REGION="${region}" && export PATH="/path/to":$${PATH} && hailctl dataproc submit ${clusterId} """
   // scalastyle:on line.size.limit
 
   import HailSupport._
 
   test("Guards: executionEnvironment") {
-    withScriptContext(projectContext) { implicit scriptContext =>
-
-      scriptContext.settings = googleSettings
+    withScriptContext(projectContext, initialSettings = googleSettings) { implicit scriptContext =>
 
       hail""
 

--- a/src/test/scala/loamstream/model/execute/FileSystemExecutionRecorderTest.scala
+++ b/src/test/scala/loamstream/model/execute/FileSystemExecutionRecorderTest.scala
@@ -54,7 +54,7 @@ final class FileSystemExecutionRecorderTest extends FunSuite {
       val memoryPerCore = Memory.inGb(1.23)
       val maxRunTime = CpuTime.inSeconds(345)
       val queueOpt = Option(Queue("foo"))
-      val containerParamsOpt = Option(ContainerParams("library/ubuntu:18.04"))
+      val containerParamsOpt = Option(ContainerParams("library/ubuntu:18.04", ""))
       
       val settings = UgerDrmSettings(cores, memoryPerCore, maxRunTime, queueOpt, containerParamsOpt)
       
@@ -205,7 +205,7 @@ final class FileSystemExecutionRecorderTest extends FunSuite {
       }
       
       val queue = Queue("foo")
-      val containerParams = ContainerParams("some-image")
+      val containerParams = ContainerParams("some-image", "")
       
       doTestWith(None, None)
       doTestWith(Some(queue), None)


### PR DESCRIPTION
- Use `--region` when invoking `hailctl` (thanks @rmkoesterer ).
- Allow specifying extra params for Singularity via `loamstream.execution.singularity` key in `loamstream.conf`.