### PR TITLE
Replace RxScala with Monix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,6 +25,7 @@ lazy val Versions = new {
   val Sttp = "2.0.6"
   val CommonsCompress = "1.20"
   val Breeze = "1.1"
+  val Monix = "3.3.0"
 }
 
 lazy val Orgs = new {
@@ -50,7 +51,7 @@ lazy val mainDeps = Seq(
   "commons-io" % "commons-io" % Versions.ApacheCommonsIO,
   "ch.qos.logback" % "logback-classic" % Versions.LogBack,
   "com.typesafe" % "config" % Versions.TypesafeConfig,
-  "io.reactivex" %% "rxscala" % Versions.RxScala,
+  //"io.reactivex" %% "rxscala" % Versions.RxScala,
   "com.typesafe.slick" %% "slick" % Versions.Slick,
   "org.rogach" %% "scallop" % Versions.Scallop,
   "com.google.cloud" % "google-cloud-storage" % Versions.GoogleCloudStorage,
@@ -64,7 +65,8 @@ lazy val mainDeps = Seq(
   "org.hsqldb" % "hsqldb" % Versions.HsqlDb,
   "com.softwaremill.sttp.client" %% "core" % Versions.Sttp,
   "org.apache.commons" % "commons-compress" % Versions.CommonsCompress,
-  "org.scalanlp" %% "breeze" % Versions.Breeze
+  "org.scalanlp" %% "breeze" % Versions.Breeze,
+  "io.monix" %% "monix" % Versions.Monix
 )
 
 lazy val testDeps = Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.7
+sbt.version=1.5.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,7 +7,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.2.2")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")
 

--- a/src/main/scala/loamstream/apps/AppWiring.scala
+++ b/src/main/scala/loamstream/apps/AppWiring.scala
@@ -93,11 +93,13 @@ import scala.concurrent.duration.Duration
 import scala.util.Try
 import scala.util.Success
 
-import rx.lang.scala.Scheduler
-import rx.lang.scala.schedulers.ExecutionContextScheduler
 import loamstream.util.DirOracle
 import loamstream.model.execute.ProtectsFilesJobCanceler
 import loamstream.model.execute.SuccessfulOutputsExecutionRecorder
+import loamstream.model.execute.SuccessfulOutputsExecutionRecorder
+import loamstream.model.execute.CompositeChunkRunner
+import loamstream.googlecloud.GcsCloudStorageClient
+import monix.execution.Scheduler
 
 
 
@@ -239,7 +241,7 @@ object AppWiring extends Loggable {
 
       import loamstream.model.execute.ExecuterHelpers._
       
-      val scheduler: Scheduler = ExecutionContextScheduler(executionContextWithThreadPool)
+      val scheduler: Scheduler = Scheduler(executionContextWithThreadPool)
 
       import scala.concurrent.duration._
       
@@ -434,7 +436,7 @@ object AppWiring extends Loggable {
 
       implicit val ec = executionContext
       
-      val scheduler = ExecutionContextScheduler(executionContext)
+      val scheduler = Scheduler(executionContext)
 
       //TODO: Make configurable?
       val pollingFrequencyInHz = 0.1
@@ -443,7 +445,7 @@ object AppWiring extends Loggable {
       
       val jobMonitor = new JobMonitor(scheduler, poller, pollingFrequencyInHz)
 
-      val jobSubmitter = QsubJobSubmitter.fromExecutable(ugerConfig, scheduler = scheduler)
+      val jobSubmitter = QsubJobSubmitter.fromExecutable(ugerConfig)(scheduler = scheduler)
       
       val accountingClient = QacctAccountingClient.useActualBinary(ugerConfig, scheduler)
       
@@ -477,7 +479,7 @@ object AppWiring extends Loggable {
 
       import loamstream.model.execute.ExecuterHelpers._
 
-      val scheduler = ExecutionContextScheduler(executionContext)
+      val scheduler = Scheduler(executionContext)
       
       implicit val ec = executionContext
 

--- a/src/main/scala/loamstream/apps/AppWiring.scala
+++ b/src/main/scala/loamstream/apps/AppWiring.scala
@@ -101,6 +101,7 @@ import loamstream.model.execute.CompositeChunkRunner
 import loamstream.googlecloud.GcsCloudStorageClient
 import monix.execution.Scheduler
 
+import scala.collection.compat._
 
 
 /**
@@ -280,7 +281,7 @@ object AppWiring extends Loggable {
       
       val googleRunner = googleChunkRunner(intent.confFile, config.googleConfig, config.hailConfig, localRunner)
 
-      val compositeRunner = CompositeChunkRunner(localRunner +: (drmRunner.toSeq ++ googleRunner))
+      val compositeRunner = CompositeChunkRunner(localRunner +: (drmRunner.to(Seq) ++ googleRunner))
       
       val toBeStopped = compositeRunner +: localEcHandle +: (drmRunnerHandles ++ compositeRunner.components)
       

--- a/src/main/scala/loamstream/apps/IndexFiles.scala
+++ b/src/main/scala/loamstream/apps/IndexFiles.scala
@@ -13,6 +13,7 @@ import loamstream.util.CanBeClosed
 import loamstream.util.Files
 import loamstream.model.jobs.JobStatus
 import java.time.LocalDateTime
+import scala.collection.compat._
 
 /**
  * @author clint
@@ -37,7 +38,7 @@ object IndexFiles {
   }
   
   private def writeRowsTo(file: Path)(rows: Iterable[Row]): Unit = {
-    val sorted = rows.toSeq.sortWith(Orderings.indexFileRowOrdering)
+    val sorted = rows.to(Seq).sortWith(Orderings.indexFileRowOrdering)
     
     CanBeClosed.using(new CSVPrinter(new FileWriter(file.toFile), Row.csvFormat)) { csvPrinter =>
       sorted.iterator.map(_.toJavaIterable).foreach(csvPrinter.printRecord)

--- a/src/main/scala/loamstream/apps/Main.scala
+++ b/src/main/scala/loamstream/apps/Main.scala
@@ -23,6 +23,7 @@ import loamstream.util.Loggable
 import loamstream.util.OneTimeLatch
 import loamstream.util.TimeUtils
 import loamstream.util.Versions
+import scala.collection.compat._
 
 
 /**
@@ -220,7 +221,7 @@ object Main extends Loggable {
     
     private def listResults(jobsToExecutions: Map[LJob, Execution]): Unit = {
       for {
-        (job, execution) <- jobsToExecutions.toSeq.sortWith(Orderings.executionTupleOrdering)
+        (job, execution) <- jobsToExecutions.to(Seq).sortWith(Orderings.executionTupleOrdering)
       } {
         info(s"${execution.status}\t(${execution.result}):\tRan $job got $execution")
       }

--- a/src/main/scala/loamstream/cli/Conf.scala
+++ b/src/main/scala/loamstream/cli/Conf.scala
@@ -15,6 +15,7 @@ import loamstream.util.IoUtils
 import loamstream.util.Loggable
 import scala.collection.mutable.ListBuffer
 import scala.collection.mutable.Buffer
+import scala.collection.compat._
 
 /**
  * Provides a command line interface for LoamStream apps
@@ -51,7 +52,7 @@ final case class Conf private (arguments: Seq[String]) extends ScallopConf(argum
     }
   }
 
-  private val listPathConverter: ValueConverter[Seq[Path]] = listArgConverter[Path](Paths.get(_)).map(_.toSeq)
+  private val listPathConverter: ValueConverter[Seq[Path]] = listArgConverter[Path](Paths.get(_)).map(_.to(Seq))
   
   // TODO: Add version info (ideally from build.sbt)?
   banner("""LoamStream is a genomic analysis stack featuring a high-level language, compiler and runtime engine.
@@ -161,7 +162,7 @@ final case class Conf private (arguments: Seq[String]) extends ScallopConf(argum
     }
       
     Conf.Values(
-      loams = loams.toOption.toSeq.flatten,
+      loams = loams.toOption.to(Seq).flatten,
       cleanDbSupplied = cleanDb.isSupplied || clean.isSupplied,
       cleanLogsSupplied = cleanLogs.isSupplied || clean.isSupplied,
       cleanScriptsSupplied = cleanScripts.isSupplied || clean.isSupplied,
@@ -251,7 +252,7 @@ object Conf {
       }
       
       val confPart: Seq[String] = {
-        conf.conf.toOption.toSeq.flatMap(confFilePath => Seq(asArgName(conf.conf), confFilePath.toString))
+        conf.conf.toOption.to(Seq).flatMap(confFilePath => Seq(asArgName(conf.conf), confFilePath.toString))
       }
       
       val noValidationPart: Seq[String] = Seq(asStringIfSupplied(noValidationSupplied, conf.noValidation))
@@ -260,10 +261,10 @@ object Conf {
       val disableHashingPart: Seq[String] = Seq(asStringIfSupplied(disableHashingSupplied, conf.disableHashing)) 
       
       val backendPart: Seq[String] = {
-        conf.backend.toOption.toSeq.flatMap(backend => Seq(asArgName(conf.backend), backend.toLowerCase))
+        conf.backend.toOption.to(Seq).flatMap(backend => Seq(asArgName(conf.backend), backend.toLowerCase))
       } 
       
-      val runPart: Seq[String] = run.toSeq.flatMap { case (what, hows) => asArgName(conf.run) +: what +: hows }
+      val runPart: Seq[String] = run.to(Seq).flatMap { case (what, hows) => asArgName(conf.run) +: what +: hows }
       
       val workerPart: Seq[String] = Seq(asStringIfSupplied(workerSupplied, conf.worker))
       

--- a/src/main/scala/loamstream/cli/Conf.scala
+++ b/src/main/scala/loamstream/cli/Conf.scala
@@ -278,7 +278,7 @@ object Conf {
       result ++= workerPart ++= cleanParts ++= confPart ++= noValidationPart ++= compileOnlyPart ++= dryRunPart ++= 
       disableHashingPart ++= backendPart ++= runPart ++= loamsPart
       
-      result.toList.filter(_.nonEmpty)
+      result.to(List).filter(_.nonEmpty)
     }
   }
   

--- a/src/main/scala/loamstream/compiler/LoamCompiler.scala
+++ b/src/main/scala/loamstream/compiler/LoamCompiler.scala
@@ -36,6 +36,8 @@ import scala.concurrent.Promise
 import scala.util.Try
 import loamstream.conf.LsSettings
 import loamstream.util.LogContext
+import scala.collection.compat._
+
 
 /** The compiler compiling Loam scripts into execution plans */
 object LoamCompiler extends Loggable {
@@ -324,7 +326,7 @@ final class LoamCompiler(
 
         TimeUtils.time("Compiling .scala files", debug(_)) {
           withRun { run =>
-            run.compileSources(sourceFiles.toList)
+            run.compileSources(sourceFiles.to(List))
           }
         }
 

--- a/src/main/scala/loamstream/compiler/LoamProject.scala
+++ b/src/main/scala/loamstream/compiler/LoamProject.scala
@@ -3,6 +3,7 @@ package loamstream.compiler
 import loamstream.loam.LoamScript
 import loamstream.conf.LoamConfig
 import loamstream.conf.LsSettings
+import scala.collection.compat._
 
 /** A collection of Loam scripts to be compiled together */
 object LoamProject {
@@ -13,7 +14,7 @@ object LoamProject {
 
   /** Returns LoamProject with iterable of scripts */
   def apply(config: LoamConfig, settings: LsSettings, scripts: Iterable[LoamScript]): LoamProject = {
-    LoamProject(config, settings, scripts.toSet)
+    LoamProject(config, settings, scripts.to(Set))
   }
 }
 

--- a/src/main/scala/loamstream/db/slick/ExecutionDaoOps.scala
+++ b/src/main/scala/loamstream/db/slick/ExecutionDaoOps.scala
@@ -16,6 +16,7 @@ import loamstream.model.execute.LsfDrmSettings
 import loamstream.model.execute.UgerDrmSettings
 import loamstream.drm.ContainerParams
 import loamstream.model.jobs.JobStatus
+import scala.collection.compat._
 
 
 /**
@@ -137,7 +138,7 @@ trait ExecutionDaoOps extends LoamDao { self: CommonDaoOps with OutputDaoOps wit
 
   private def tieOutputsToExecution(execution: Execution, executionId: Int): Seq[OutputRow] = {
     def toOutputRows(f: StoreRecord => OutputRow): Seq[OutputRow] = {
-      execution.outputs.toSeq.map(f)
+      execution.outputs.to(Seq).map(f)
     }
 
     val outputs = {

--- a/src/main/scala/loamstream/db/slick/OutputDaoOps.scala
+++ b/src/main/scala/loamstream/db/slick/OutputDaoOps.scala
@@ -6,6 +6,7 @@ import loamstream.db.LoamDao
 import loamstream.model.jobs.StoreRecord
 import loamstream.util.Paths
 import slick.jdbc.JdbcProfile
+import scala.collection.compat._
 
 /**
  * @author clint
@@ -75,7 +76,7 @@ trait OutputDaoOps extends LoamDao { self: CommonDaoOps =>
     }
 
     def outputsByPaths(locs: Iterable[String]): Query[tables.Outputs, OutputRow, Seq] = {
-      val rawPaths = locs.toSet
+      val rawPaths = locs.to(Set)
 
       outputsByRawPaths(rawPaths)
     }

--- a/src/main/scala/loamstream/db/slick/Tables.scala
+++ b/src/main/scala/loamstream/db/slick/Tables.scala
@@ -10,6 +10,7 @@ import slick.jdbc.meta.MTable
 import slick.ast.ColumnOption
 import scala.reflect.ClassTag
 import slick.lifted.ForeignKeyQuery
+import scala.collection.compat._
 
 /**
  * @author clint
@@ -145,7 +146,7 @@ final class Tables(val driver: JdbcProfile) extends DbHelpers with Loggable {
         MTable.getTables(Some("PUBLIC"), Some("PUBLIC"), Some(tableName), Some(Seq("TABLE"))).headOption
       }
       
-      allTableNames.toSet[String].flatMap { tableName =>
+      allTableNames.to(Set).flatMap { tableName =>
         val queryForTable = for {
           tableMetadataOpt <- queryForTableMetadata(tableName)
         } yield tableMetadataOpt.map(_.name.name)

--- a/src/main/scala/loamstream/drm/AccountingCommandInvoker.scala
+++ b/src/main/scala/loamstream/drm/AccountingCommandInvoker.scala
@@ -5,7 +5,7 @@ import scala.concurrent.ExecutionContext
 import loamstream.util.CommandInvoker
 import loamstream.util.Loggable
 import loamstream.util.Processes
-import rx.lang.scala.Scheduler
+import monix.execution.Scheduler
 
 /**
  * @author clint
@@ -31,7 +31,11 @@ object AccountingCommandInvoker {
       
       val notRetrying = maxRetries == 0
       
-      val invokeOnce = new CommandInvoker.Async.JustOnce[P](binaryName, invokeBinaryFor)
+      val invokeOnce = {
+        implicit val sch = scheduler
+        
+        new CommandInvoker.Async.JustOnce[P](binaryName, invokeBinaryFor)
+      }
       
       if(notRetrying) {
         invokeOnce

--- a/src/main/scala/loamstream/drm/DrmChunkRunner.scala
+++ b/src/main/scala/loamstream/drm/DrmChunkRunner.scala
@@ -24,9 +24,12 @@ import loamstream.util.Classes.simpleNameOf
 import loamstream.util.Loggable
 import loamstream.util.Observables
 import loamstream.util.Terminable
-import rx.lang.scala.Observable
+import monix.execution.Scheduler
+import monix.reactive.Observable
 import loamstream.util.TimeUtils
 import loamstream.util.ExitCodes
+import cats.kernel.Eq
+import loamstream.model.jobs.commandline.HasCommandLine
 
 
 /**
@@ -162,7 +165,7 @@ final case class DrmChunkRunner(
       
       for {
         (tid, status) <- monitor(taskIds)
-        wrapper <- jobsById.get(tid).map(Observable.just(_)).getOrElse(Observable.empty)
+        wrapper <- jobsById.get(tid).map(Observable(_)).getOrElse(Observable.empty)
       } yield {
         (tid, wrapper, status)
       }
@@ -262,6 +265,8 @@ object DrmChunkRunner extends Loggable {
     val jobsToExecutionObservables = drmJobsToExecutionObservables.map { case (jobWrapper, runData) => 
       (jobWrapper.commandLineJob, runData) 
     }
+    
+    implicit val eqTuple: Eq[(HasCommandLine, RunData)] = Eq.fromUniversalEquals
 
     jobsToExecutionObservables.distinctUntilChanged
   }

--- a/src/main/scala/loamstream/drm/DrmChunkRunner.scala
+++ b/src/main/scala/loamstream/drm/DrmChunkRunner.scala
@@ -31,7 +31,7 @@ import loamstream.util.TimeUtils
 import loamstream.util.ExitCodes
 import cats.kernel.Eq
 import loamstream.model.jobs.commandline.HasCommandLine
-
+import scala.collection.compat._
 
 /**
  * @author clint
@@ -83,7 +83,7 @@ final case class DrmChunkRunner(
       s"For now, we only know how to run ${simpleNameOf[CommandLineJob]}s on a DRM system")
 
     // Filter out NoOpJob's
-    val commandLineJobs = jobs.toSeq.collect { case clj: CommandLineJob => clj }
+    val commandLineJobs = jobs.to(Seq).collect { case clj: CommandLineJob => clj }
 
     //Group Jobs by their uger settings, and run each group.  This is necessary because the jobs in a group will
     //be run as 1 Uger task array, and Uger params are per-task-array.

--- a/src/main/scala/loamstream/drm/DrmChunkRunner.scala
+++ b/src/main/scala/loamstream/drm/DrmChunkRunner.scala
@@ -71,7 +71,7 @@ final case class DrmChunkRunner(
    * will throw otherwise.
    */
   override def run(
-      jobs: Set[LJob], 
+      jobs: Iterable[LJob], 
       jobOracle: JobOracle): Observable[(LJob, RunData)] = {
 
     debug(s"${getClass.getSimpleName}: Running ${jobs.size} jobs: ")

--- a/src/main/scala/loamstream/drm/JobMonitor.scala
+++ b/src/main/scala/loamstream/drm/JobMonitor.scala
@@ -19,6 +19,7 @@ import scala.concurrent.duration.FiniteDuration
 import monix.reactive.OverflowStrategy
 import loamstream.util.Observables
 import loamstream.model.jobs.DrmJobOracle
+import scala.collection.compat._
 
 /**
  * @author clint
@@ -120,7 +121,7 @@ object JobMonitor extends Loggable {
       val result = stillWaitingFor.isEmpty 
       
       if(result) {
-        debug(s"Jobs are all finished: ${stillWaitingFor.toSeq.sorted.mkString(",")}")
+        debug(s"Jobs are all finished: ${stillWaitingFor.to(Seq).sorted.mkString(",")}")
         
         //Note side effect :(
         stopSignal.onNext(())

--- a/src/main/scala/loamstream/drm/JobMonitor.scala
+++ b/src/main/scala/loamstream/drm/JobMonitor.scala
@@ -81,7 +81,7 @@ final class JobMonitor(
    */
   def monitor(oracle: DrmJobOracle)(taskIds: Iterable[DrmTaskId]): Observable[(DrmTaskId, DrmStatus)] = {
     
-    val distinctIdsBeingPolledFor = taskIds.toSet
+    val distinctIdsBeingPolledFor = taskIds.to(Set)
     
     val stopSignal: Subject[Unit, Unit] = PublishSubject()
     

--- a/src/main/scala/loamstream/drm/JobSubmitter.scala
+++ b/src/main/scala/loamstream/drm/JobSubmitter.scala
@@ -2,7 +2,8 @@ package loamstream.drm
 
 import loamstream.model.execute.DrmSettings
 import loamstream.util.Terminable
-import rx.lang.scala.Observable
+import monix.reactive.Observable
+
 
 /**
  * @author clint

--- a/src/main/scala/loamstream/drm/Poller.scala
+++ b/src/main/scala/loamstream/drm/Poller.scala
@@ -3,8 +3,7 @@ package loamstream.drm
 import scala.util.Try
 
 import loamstream.util.Terminable
-import rx.lang.scala.Observable
-import loamstream.util.CommandInvoker
+import monix.reactive.Observable
 
 /**
  * @author clint

--- a/src/main/scala/loamstream/drm/lsf/BacctAccountingClient.scala
+++ b/src/main/scala/loamstream/drm/lsf/BacctAccountingClient.scala
@@ -25,7 +25,8 @@ import loamstream.util.CommandInvoker
 import loamstream.util.Loggable
 import loamstream.util.Options
 import loamstream.util.Tries
-import rx.lang.scala.Scheduler
+import monix.execution.Scheduler
+
 
 /**
  * @author clint

--- a/src/main/scala/loamstream/drm/lsf/BjobsPoller.scala
+++ b/src/main/scala/loamstream/drm/lsf/BjobsPoller.scala
@@ -14,8 +14,8 @@ import loamstream.util.Maps
 import loamstream.util.Options
 import loamstream.util.Tries
 import loamstream.drm.DrmTaskId
-import rx.lang.scala.Observable
 import loamstream.util.Observables
+import monix.reactive.Observable
 
 /**
  * @author clint

--- a/src/main/scala/loamstream/drm/lsf/BjobsPoller.scala
+++ b/src/main/scala/loamstream/drm/lsf/BjobsPoller.scala
@@ -17,6 +17,7 @@ import loamstream.drm.DrmTaskId
 import loamstream.util.Observables
 import monix.reactive.Observable
 import loamstream.model.jobs.DrmJobOracle
+import scala.collection.compat._
 
 /**
  * @author clint
@@ -161,7 +162,7 @@ object BjobsPoller extends InvokesBjobs.Companion(new BjobsPoller(_)) {
     
     val indices = lsfJobIds.map(_.taskIndex)
     
-    val Seq(baseJobId) = baseJobIds.toSeq
+    val Seq(baseJobId) = baseJobIds.to(Seq)
         
     val toQueryFor = s"${baseJobId}[${indices.mkString(",")}]"
     

--- a/src/main/scala/loamstream/drm/lsf/BjobsPoller.scala
+++ b/src/main/scala/loamstream/drm/lsf/BjobsPoller.scala
@@ -39,7 +39,7 @@ final class BjobsPoller private[lsf] (pollingFn: InvocationFn[Set[DrmTaskId]]) e
     
     import loamstream.util.Maps.Implicits._
     
-    val indicesByBaseId: Map[String, Set[DrmTaskId]] = allLsfJobIds.toSet.groupBy(_.jobId)
+    val indicesByBaseId: Map[String, Set[DrmTaskId]] = allLsfJobIds.to(Set).groupBy(_.jobId)
     
     val jobIdsToStatusAttempts = Observables.merge(indicesByBaseId.values.map(runChunk))
     
@@ -156,7 +156,7 @@ object BjobsPoller extends InvokesBjobs.Companion(new BjobsPoller(_)) {
   private[lsf] override def makeTokens(actualExecutable: String, lsfJobIds: Set[DrmTaskId]): Seq[String] = {
     require(lsfJobIds.nonEmpty, s"Can't build '${actualExecutable}' command-line from empty set of job ids")
     
-    val baseJobIds = lsfJobIds.map(_.jobId).toSet
+    val baseJobIds = lsfJobIds.map(_.jobId).to(Set)
     
     require(baseJobIds.size == 1, s"All LSF job ids in this chunk should have the same base, but got $lsfJobIds")
     

--- a/src/main/scala/loamstream/drm/lsf/BsubJobSubmitter.scala
+++ b/src/main/scala/loamstream/drm/lsf/BsubJobSubmitter.scala
@@ -21,7 +21,7 @@ import loamstream.conf.LsfConfig
 import loamstream.util.RunResults
 import loamstream.util.Processes
 import loamstream.drm.DrmTaskId
-import rx.lang.scala.Observable
+import monix.reactive.Observable
 
 /**
  * @author clint
@@ -33,7 +33,7 @@ final class BsubJobSubmitter private[lsf] (
   import BsubJobSubmitter._
   
   override def submitJobs(drmSettings: DrmSettings, taskArray: DrmTaskArray): Observable[DrmSubmissionResult] = {
-    val runAttemptObs = Observable.just(submissionFn(drmSettings, taskArray))
+    val runAttemptObs = Observable(submissionFn(drmSettings, taskArray))
     
     runAttemptObs.map { attempt =>
       attempt.map(toDrmSubmissionResult(taskArray)) match {

--- a/src/main/scala/loamstream/drm/lsf/BsubJobSubmitter.scala
+++ b/src/main/scala/loamstream/drm/lsf/BsubJobSubmitter.scala
@@ -22,6 +22,7 @@ import loamstream.util.RunResults
 import loamstream.util.Processes
 import loamstream.drm.DrmTaskId
 import monix.reactive.Observable
+import scala.collection.compat._
 
 /**
  * @author clint
@@ -154,7 +155,7 @@ object BsubJobSubmitter extends Loggable {
     
     val coresPart = Seq("-n", numCores.toString, "-R", s"span[hosts=1]")
     
-    val queuePart: Seq[String] = drmSettings.queue.toSeq.flatMap(q => Seq("-q", q.name))
+    val queuePart: Seq[String] = drmSettings.queue.to(Seq).flatMap(q => Seq("-q", q.name))
     
     val jobNamePart = Seq("-J", s"${taskArray.drmJobName}[1-${taskArray.size}]")
     

--- a/src/main/scala/loamstream/drm/uger/QacctAccountingClient.scala
+++ b/src/main/scala/loamstream/drm/uger/QacctAccountingClient.scala
@@ -23,7 +23,7 @@ import loamstream.util.CommandInvoker
 import loamstream.util.Loggable
 import loamstream.util.Options
 import loamstream.util.Tries
-import rx.lang.scala.Scheduler
+import monix.execution.Scheduler
 
 
 /**

--- a/src/main/scala/loamstream/drm/uger/QacctInvoker.scala
+++ b/src/main/scala/loamstream/drm/uger/QacctInvoker.scala
@@ -2,7 +2,6 @@ package loamstream.drm.uger
 
 import loamstream.drm.AccountingCommandInvoker
 import loamstream.drm.DrmTaskId
-import rx.lang.scala.Scheduler
 import scala.concurrent.ExecutionContext
 import loamstream.util.CommandInvoker
 import loamstream.util.Processes
@@ -12,6 +11,7 @@ import loamstream.util.RunResults
 import loamstream.util.ValueBox
 import loamstream.conf.UgerConfig
 import scala.concurrent.duration.Duration
+import monix.execution.Scheduler
 
 /**
  * @author clint

--- a/src/main/scala/loamstream/drm/uger/Qstat.scala
+++ b/src/main/scala/loamstream/drm/uger/Qstat.scala
@@ -8,6 +8,7 @@ import loamstream.util.LogContext
 import loamstream.util.Processes
 import loamstream.util.RateLimitedCache
 import loamstream.util.RunResults
+import monix.execution.Scheduler
 
 /**
  * @author clint
@@ -23,7 +24,7 @@ object Qstat {
   final def commandInvoker(
       pollingFrequencyInHz: Double,
       actualExecutable: String = "qstat")
-     (implicit ec: ExecutionContext, logCtx: LogContext): CommandInvoker.Async[Unit] = {
+     (implicit scheduler: Scheduler, logCtx: LogContext): CommandInvoker.Async[Unit] = {
     
     //Unit and ignored args are obviously a smell, but a more principled refactoring will have to wait.
     def invocationFn(ignored: Unit): Try[RunResults] = {

--- a/src/main/scala/loamstream/drm/uger/QstatPoller.scala
+++ b/src/main/scala/loamstream/drm/uger/QstatPoller.scala
@@ -52,7 +52,7 @@ final class QstatPoller private[uger] (qstatInvoker: CommandInvoker.Async[Unit])
     }
 
     //The Set of distinct DrmTaskIds (jobId/task index coords) that we're polling for
-    val drmTaskIdSet = drmTaskIds.toSet
+    val drmTaskIdSet = drmTaskIds.to(Set)
 
     //Parse out DrmTaskIds and DrmStatuses from raw qstat output (one line per task)
     val pollingResultsFromQstatObs = qstatResultObs.map { qstatResults =>
@@ -222,7 +222,7 @@ object QstatPoller extends Loggable {
       idsWereLookingFor: Iterable[DrmTaskId],
       lines: Seq[String]): Iterator[Try[PollResult]] = {
 
-      val idsWereLookingForSet = idsWereLookingFor.toSet
+      val idsWereLookingForSet = idsWereLookingFor.to(Set)
 
       val isIdWeCareAbout: PollResult => Boolean = {
         case (taskId, _) => idsWereLookingForSet.contains(taskId)

--- a/src/main/scala/loamstream/drm/uger/QstatPoller.scala
+++ b/src/main/scala/loamstream/drm/uger/QstatPoller.scala
@@ -31,6 +31,7 @@ import loamstream.util.CanBeClosed
 import scala.io.Source
 import loamstream.util.Iterators
 import loamstream.util.ValueBox
+import scala.collection.compat._
 
 /**
  * @author clint
@@ -79,7 +80,7 @@ final class QstatPoller private[uger] (qstatInvoker: CommandInvoker.Async[Unit])
       val exitCodeStatusObses = {
         notFoundByQstatByTaskArrayId.values.iterator.take(ThisMachine.numCpus).map { drmTaskIdsInTaskArray =>  
           getExitCodes(oracle)(drmTaskIdsInTaskArray)
-        }.toSeq
+        }.to(Seq)
       }
 
       val exitCodeStatuesObs = Observables.merge(exitCodeStatusObses)

--- a/src/main/scala/loamstream/drm/uger/QstatQacctPoller.scala
+++ b/src/main/scala/loamstream/drm/uger/QstatQacctPoller.scala
@@ -50,7 +50,7 @@ final class QstatQacctPoller private[uger] (
     //Parse out DrmTaskIds and DrmStatuses from raw qstat output (one line per task)
     val pollingResultsFromQstatObs = qstatResultObs.map { qstatResults =>
       QstatSupport.getByTaskId(drmTaskIdSet, qstatResults.stdout)
-    }.asyncBoundary(OverflowStrategy.DropOld(0))
+    }.asyncBoundary(Observables.defaultOverflowStrategy)
 
     //For all the jobs that we're polling for that were not mentioned by qstat, assume they've finished
     //(qstat only returns info about running jobs) and invoke qacct to determine their final status.
@@ -81,7 +81,7 @@ final class QstatQacctPoller private[uger] (
       //Concatentate results from qstat with those from qacct, wrapping in Trys as needed.
       Observable.from(byTaskId) ++ {
         qacctResultsObs.map { case (tid, status) => (tid, Success(status)) }
-      }.asyncBoundary(OverflowStrategy.DropOld(0))
+      }.asyncBoundary(Observables.defaultOverflowStrategy)
     }
   }
 

--- a/src/main/scala/loamstream/drm/uger/Qsub.scala
+++ b/src/main/scala/loamstream/drm/uger/Qsub.scala
@@ -13,6 +13,7 @@ import loamstream.util.LogContext
 import loamstream.util.Processes
 import loamstream.util.RunResults
 import monix.execution.Scheduler
+import scala.collection.compat._
 
 /**
  * @author clint
@@ -85,7 +86,7 @@ object Qsub {
       drmScriptFile.toAbsolutePath.toString
     }
 
-    actualExecutable +: (staticPartFromUgerConfig.toList ++ dynamicPart)
+    actualExecutable +: (staticPartFromUgerConfig.to(List) ++ dynamicPart)
   }
     
   final def commandInvoker(

--- a/src/main/scala/loamstream/drm/uger/Qsub.scala
+++ b/src/main/scala/loamstream/drm/uger/Qsub.scala
@@ -12,7 +12,7 @@ import loamstream.util.CommandInvoker
 import loamstream.util.LogContext
 import loamstream.util.Processes
 import loamstream.util.RunResults
-import rx.lang.scala.Scheduler
+import monix.execution.Scheduler
 
 /**
  * @author clint
@@ -91,7 +91,7 @@ object Qsub {
   final def commandInvoker(
       ugerConfig: UgerConfig,
       actualExecutable: String = "qsub",
-      scheduler: Scheduler)(implicit ec: ExecutionContext, logCtx: LogContext): CommandInvoker.Async[Params] = {
+      scheduler: Scheduler)(implicit logCtx: LogContext): CommandInvoker.Async[Params] = {
 
     def invocationFn(params: Params): Try[RunResults] = {
       val tokens = makeTokens(actualExecutable, params)
@@ -101,7 +101,7 @@ object Qsub {
       Processes.runSync(tokens)()
     }
     
-    val justOnce = new CommandInvoker.Async.JustOnce[Params](actualExecutable, invocationFn)
+    val justOnce = new CommandInvoker.Async.JustOnce[Params](actualExecutable, invocationFn)(scheduler, logCtx)
     
     new CommandInvoker.Async.Retrying(justOnce, ugerConfig.maxRetries, scheduler = scheduler)
   }

--- a/src/main/scala/loamstream/drm/uger/RateLimitedQacctInvoker.scala
+++ b/src/main/scala/loamstream/drm/uger/RateLimitedQacctInvoker.scala
@@ -8,9 +8,9 @@ import loamstream.util.ValueBox
 import loamstream.util.Processes
 import loamstream.util.CommandInvoker
 import loamstream.util.Loggable
-import rx.lang.scala.Scheduler
 import scala.concurrent.ExecutionContext
 import scala.util.Try
+import monix.execution.Scheduler
 
 /**
  * @author clint
@@ -22,8 +22,11 @@ final class RateLimitedQacctInvoker private[uger] (
     maxSize: Int, 
     maxAge: Duration,
     maxRetries: Int,
-    scheduler: Scheduler)(implicit ec: ExecutionContext) extends Loggable {
+    scheduler: Scheduler) extends Loggable {
 
+  //TODO
+  private implicit val sch = scheduler
+  
   val commandInvoker: CommandInvoker.Async.JustOnce[String] = new CommandInvoker.Async.JustOnce[String](
     binaryName, 
     taskArrayId => getLimiter(taskArrayId).apply())
@@ -71,7 +74,7 @@ object RateLimitedQacctInvoker extends Loggable {
       maxSize: Int, 
       maxAge: Duration,
       maxRetries: Int, 
-      scheduler: Scheduler)(implicit ec: ExecutionContext): RateLimitedQacctInvoker = {
+      scheduler: Scheduler): RateLimitedQacctInvoker = {
     
     def invokeBinary(taskArrayJobId: JobId): Try[RunResults] = {
       val tokens = makeTokens(binaryName, taskArrayJobId)
@@ -87,7 +90,7 @@ object RateLimitedQacctInvoker extends Loggable {
         maxSize = maxSize, 
         maxAge = maxAge,
         maxRetries = maxRetries,
-        scheduler = scheduler)(ec)
+        scheduler = scheduler)
   }
   
   private[uger] def makeTokens(actualBinary: String = "qacct", jobNumber: JobId): Seq[String] = {

--- a/src/main/scala/loamstream/googlecloud/GcsCloudStorageClient.scala
+++ b/src/main/scala/loamstream/googlecloud/GcsCloudStorageClient.scala
@@ -12,6 +12,8 @@ import loamstream.util.Loggable
 
 import scala.util.Try
 
+import scala.collection.compat._
+
 
 /**
  * @author kyuksel
@@ -28,7 +30,7 @@ final case class GcsCloudStorageClient(driver: CloudStorageDriver) extends Cloud
   override def hash(uri: URI): Option[Hash] = {
     val bs = blobs(uri)
 
-    bs.toSeq match {
+    bs.to(Seq) match {
       case Nil => None
       //For a single blob, use the hash computed by Google
       case Seq(only) => Hash.fromStrings(Some(only.hash), hashAlgorithm.algorithmName)

--- a/src/main/scala/loamstream/googlecloud/GoogleCloudChunkRunner.scala
+++ b/src/main/scala/loamstream/googlecloud/GoogleCloudChunkRunner.scala
@@ -146,7 +146,7 @@ final case class GoogleCloudChunkRunner(
     }
     
     val futureResult = {
-      implicit val sch = singleThreadedScheduler
+      implicit val sch = Scheduler.Implicits.global
       
       delegate.run(Set(job), jobOracle).map(addCluster(googleSettings.clusterId)).lastAsFuture
     }

--- a/src/main/scala/loamstream/googlecloud/GoogleCloudChunkRunner.scala
+++ b/src/main/scala/loamstream/googlecloud/GoogleCloudChunkRunner.scala
@@ -25,9 +25,8 @@ import loamstream.util.ExecutorServices
 import loamstream.util.Loggable
 import loamstream.util.Terminable
 import loamstream.util.ValueBox
-import rx.lang.scala.Observable
-import rx.lang.scala.Scheduler
-import rx.lang.scala.schedulers.ExecutionContextScheduler
+import monix.reactive.Observable
+import monix.execution.Scheduler
 
 
 /**
@@ -45,7 +44,7 @@ final case class GoogleCloudChunkRunner(
     ExecutionContext.fromExecutorService(singleThreadedExecutor)
   }
   
-  private lazy val singleThreadedScheduler: Scheduler = ExecutionContextScheduler(singleThreadedExecutionContext)
+  private lazy val singleThreadedScheduler: Scheduler = Scheduler(singleThreadedExecutionContext)
   
   private val currentClusterConfig: ValueBox[Option[ClusterConfig]] = ValueBox(None)
   
@@ -147,6 +146,8 @@ final case class GoogleCloudChunkRunner(
     }
     
     val futureResult = {
+      implicit val sch = singleThreadedScheduler
+      
       delegate.run(Set(job), jobOracle).map(addCluster(googleSettings.clusterId)).lastAsFuture
     }
     

--- a/src/main/scala/loamstream/googlecloud/GoogleCloudChunkRunner.scala
+++ b/src/main/scala/loamstream/googlecloud/GoogleCloudChunkRunner.scala
@@ -26,6 +26,8 @@ import loamstream.util.ValueBox
 import monix.execution.Scheduler
 import monix.reactive.Observable
 
+import scala.collection.compat._
+
 
 /**
  * @author clint
@@ -128,7 +130,7 @@ final case class GoogleCloudChunkRunner(
     //on the same cluster simultaneously
     //NB: .share() is required, or else jobs will run multiple times :\
     //NB: Monix flatMap is like Rx concatMap, so that ordering and at-most-once semantics are preserved
-    Observable(jobs.toSeq: _*).share(singleThreadedScheduler).executeOn(singleThreadedScheduler).flatMap(doRunSingle)
+    Observable(jobs.to(Seq): _*).share(singleThreadedScheduler).executeOn(singleThreadedScheduler).flatMap(doRunSingle)
   }
 
   private[googlecloud] def runSingle(

--- a/src/main/scala/loamstream/googlecloud/HailLoamSyntax.scala
+++ b/src/main/scala/loamstream/googlecloud/HailLoamSyntax.scala
@@ -4,6 +4,7 @@ import loamstream.loam.LoamCmdTool
 import loamstream.loam.LoamScriptContext
 import loamstream.loam.LanguageSupport
 import loamstream.loam.LoamCmdSyntax
+import scala.collection.compat._
 
 /**
  * @author clint
@@ -86,7 +87,7 @@ trait HailLoamSyntax {
           
       //NB: Combine prefix part with first user-provided part, if the latter exists.  This matches what
       //the compiler would provide.
-      val newParts: Seq[String] = stringContext.parts.toSeq match {
+      val newParts: Seq[String] = stringContext.parts.to(Seq) match {
         case Nil => Seq(hailctlPrefixPart)
         case firstPart +: otherParts => s"${hailctlPrefixPart}${firstPart}" +: otherParts
       }

--- a/src/main/scala/loamstream/loam/LoamGraph.scala
+++ b/src/main/scala/loamstream/loam/LoamGraph.scala
@@ -3,15 +3,15 @@ package loamstream.loam
 import java.net.URI
 import java.nio.file.Path
 
-import loamstream.loam.LoamGraph.StoreLocation
 import loamstream.model.Store
 import loamstream.model.Tool
 import loamstream.model.Tool.AllStores
 import loamstream.model.Tool.InputsAndOutputs
-import loamstream.util.Sequence
-import loamstream.util.Traversables
-import loamstream.util.BiMap
 import loamstream.model.execute.Settings
+import loamstream.util.BiMap
+import loamstream.util.Sequence
+
+import scala.collection.compat._
 
 /** The graph of all Loam stores and tools and their relationships */
 object LoamGraph {
@@ -95,10 +95,10 @@ final case class LoamGraph(
           
           (toolInputStores, toolOutputStores)
         }
-        case InputsAndOutputs(inputs, outputs) => (inputs.toSet, outputs.toSet)
+        case InputsAndOutputs(inputs, outputs) => (inputs.to(Set), outputs.to(Set))
       }
 
-      import Traversables.Implicits._
+      import loamstream.util.Traversables.Implicits._
       
       val outputsWithProducer: Map[Store, Tool] = toolOutputStores.mapTo(_ => tool)
       

--- a/src/main/scala/loamstream/loam/LoamGraphValidation.scala
+++ b/src/main/scala/loamstream/loam/LoamGraphValidation.scala
@@ -4,6 +4,7 @@ import loamstream.model.{Store, Tool}
 import loamstream.util.Validation
 import loamstream.util.Validation.{BulkIssue, BulkValidation, Issue, Severity, SimpleIssue}
 import loamstream.util.Sets
+import scala.collection.compat._
 
 /**
   * LoamStream
@@ -37,23 +38,23 @@ object LoamGraphValidation {
   trait LoamGlobalRule[Details] extends Validation[LoamGraph]
 
   trait LoamStoreRule[Details] extends LoamBulkRule[Store, Details] {
-    override def targets(graph: LoamGraph): Seq[Store] = graph.stores.toSeq
+    override def targets(graph: LoamGraph): Seq[Store] = graph.stores.to(Seq)
   }
 
   trait LoamToolRule[Details] extends LoamBulkRule[Tool, Details] {
-    override def targets(graph: LoamGraph): Seq[Tool] = graph.tools.toSeq
+    override def targets(graph: LoamGraph): Seq[Tool] = graph.tools.to(Seq)
   }
 
   trait LoamProducerRule[Details] extends LoamBulkRule[(Store, Tool), Details] {
     override def targets(graph: LoamGraph): Seq[(Store, Tool)] =
       graph.stores.flatMap(store =>
-        graph.storeProducers.get(store).map(tool => (store, tool))).toSeq
+        graph.storeProducers.get(store).map(tool => (store, tool))).to(Seq)
   }
 
   trait LoamConsumerRule[Details] extends LoamBulkRule[(Store, Tool), Details] {
     override def targets(graph: LoamGraph): Seq[(Store, Tool)] =
       graph.stores.flatMap(store =>
-        graph.storeConsumers.getOrElse(store, Set.empty).map(tool => (store, tool))).toSeq
+        graph.storeConsumers.getOrElse(store, Set.empty).map(tool => (store, tool))).to(Seq)
   }
 
   object eachStoreIsInputOrHasProducer extends LoamStoreRule[Unit] {
@@ -107,7 +108,7 @@ object LoamGraphValidation {
   }
 
   object noToolsPrecedeInitialTool extends LoamToolRule[Set[Tool]] {
-    override def targets(graph: LoamGraph): Seq[Tool] = graph.initialTools.toSeq
+    override def targets(graph: LoamGraph): Seq[Tool] = graph.initialTools.to(Seq)
 
     override def apply(graph: LoamGraph, tool: Tool): Seq[BulkIssue[LoamGraph, Tool, Set[Tool]]] = {
       val precedingTools = graph.toolInputs.getOrElse(tool, Set.empty).flatMap(graph.storeProducers.get)
@@ -119,7 +120,7 @@ object LoamGraphValidation {
   }
 
   object noToolsSucceedFinalTool extends LoamToolRule[Set[Tool]] {
-    override def targets(graph: LoamGraph): Seq[Tool] = graph.finalTools.toSeq
+    override def targets(graph: LoamGraph): Seq[Tool] = graph.finalTools.to(Seq)
 
     override def apply(graph: LoamGraph, tool: Tool): Seq[BulkIssue[LoamGraph, Tool, Set[Tool]]] = {
       val succeedingTools =

--- a/src/main/scala/loamstream/loam/LoamToken.scala
+++ b/src/main/scala/loamstream/loam/LoamToken.scala
@@ -1,12 +1,8 @@
 package loamstream.loam
 
-import java.nio.file.Paths
-
 import loamstream.model.Store
-import java.nio.file.Path
-import loamstream.model.UriStore
-import loamstream.model.PathStore
-import scala.reflect.ClassTag
+
+import scala.collection.compat._
 
 /**
  * LoamStream
@@ -21,7 +17,7 @@ sealed trait LoamToken {
 object LoamToken {
 
   def storesFromTokens(tokens: Seq[LoamToken]): Set[Store] = {
-    tokens.collect { case StoreToken(store) => store }.toSet
+    tokens.collect { case StoreToken(store) => store }.to(Set)
   }
 
   final case class StringToken(string: String) extends LoamToken {

--- a/src/main/scala/loamstream/loam/intake/AggregatorVarIdFormat.scala
+++ b/src/main/scala/loamstream/loam/intake/AggregatorVarIdFormat.scala
@@ -1,5 +1,7 @@
 package loamstream.loam.intake
 
+import scala.collection.compat._
+
 /**
  * @author clint
  * Feb 12, 2020
@@ -22,6 +24,6 @@ object AggregatorVarIdFormat {
     
     val values: Set[Component] = Set(Chrom, Pos, Ref, Alt)
     
-    val names: Seq[String] = values.toSeq.map(_.name).sorted
+    val names: Seq[String] = values.to(Seq).map(_.name).sorted
   }
 }

--- a/src/main/scala/loamstream/loam/intake/AwsRowSink.scala
+++ b/src/main/scala/loamstream/loam/intake/AwsRowSink.scala
@@ -15,6 +15,7 @@ import org.broadinstitute.dig.aws.Implicits
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException
 import loamstream.util.AwsClient
 import scala.util.Try
+import scala.collection.compat._
 
 /**
  * @author clint
@@ -235,6 +236,6 @@ final case class AwsRowSink(
   }
   
   private[intake] def toJson(row: RenderableJsonRow): JObject = {
-    JObject(row.jsonValues.toList)
+    JObject(row.jsonValues.to(List))
   }
 }

--- a/src/main/scala/loamstream/loam/intake/Chromosomes.scala
+++ b/src/main/scala/loamstream/loam/intake/Chromosomes.scala
@@ -1,9 +1,11 @@
 package loamstream.loam.intake
 
+import scala.collection.compat._
+
 /**
  * @author clint
  * Nov 16, 2020
  */
 object Chromosomes {
-  val names: Iterable[String] = ((1 to 22).map(_.toString) ++ Seq("X", "Y", "XY", "MT")).toSet 
+  val names: Iterable[String] = (1 to 22).map(_.toString).to(Set) ++ Set("X", "Y", "XY", "MT") 
 }

--- a/src/main/scala/loamstream/loam/intake/DataRow.scala
+++ b/src/main/scala/loamstream/loam/intake/DataRow.scala
@@ -5,6 +5,7 @@ import loamstream.loam.intake.flip.Disposition
 import scala.util.Failure
 import org.json4s._
 import org.json4s.JsonAST.JNumber
+import scala.collection.compat._
 
 /**
  * @author clint
@@ -34,7 +35,7 @@ object DataRow {
   }
   
   final case class JsonDataRow(json: JObject, recordNumber: Long, isSkipped: Boolean = false) extends DataRow {
-    override def headers: Seq[String] = json.values.keys.toList
+    override def headers: Seq[String] = json.values.keys.to(List)
     
     override def hasField(name: String): Boolean = json.obj.exists { case JField(n, _) => n == name } 
     

--- a/src/main/scala/loamstream/loam/intake/IntakeSyntax.scala
+++ b/src/main/scala/loamstream/loam/intake/IntakeSyntax.scala
@@ -215,7 +215,7 @@ trait IntakeSyntax extends Interpolators with Metrics with RowFilters with RowTr
       import org.json4s._
       
       rowSink match {
-        case aws: AwsRowSink => aws.commit(JObject(metadata.asJson.toList))
+        case aws: AwsRowSink => aws.commit(JObject(metadata.asJson.to(List)))
         case _ => ()
       }
     }

--- a/src/main/scala/loamstream/loam/intake/IntakeSyntax.scala
+++ b/src/main/scala/loamstream/loam/intake/IntakeSyntax.scala
@@ -29,6 +29,7 @@ import loamstream.util.Loggable
 import loamstream.util.Terminable
 import loamstream.util.Throwables
 import loamstream.util.TimeUtils
+import scala.collection.compat._
 
 
 /**
@@ -183,7 +184,7 @@ trait IntakeSyntax extends Interpolators with Metrics with RowFilters with RowTr
     def using(flipDetector: => FlipDetector): ViaTarget = new ViaTarget(rowSink, rows, flipDetector)
   }
   
-  private[intake] def asCloseable[A](a: AnyRef): Seq[Closeable] = Option(a).collect { case c: Closeable => c }.toSeq
+  private[intake] def asCloseable[A](a: AnyRef): Seq[Closeable] = Option(a).collect { case c: Closeable => c }.to(Seq)
   
   final class ViaTarget(
       rowSink: RowSink[RenderableJsonRow], 

--- a/src/main/scala/loamstream/loam/intake/RowSink.scala
+++ b/src/main/scala/loamstream/loam/intake/RowSink.scala
@@ -8,6 +8,9 @@ import java.nio.file.Path
 
 import org.apache.commons.csv.CSVFormat
 
+import scala.collection.compat._
+
+
 /**
  * @author clint
  * Oct 13, 2020
@@ -28,7 +31,7 @@ object RowSink {
       import org.json4s._
       import org.json4s.jackson.JsonMethods._
       
-      val obj = JObject(row.jsonValues.toList)
+      val obj = JObject(row.jsonValues.to(List))
       
       compact(render(obj))
     }

--- a/src/main/scala/loamstream/loam/intake/dga/Annotation.scala
+++ b/src/main/scala/loamstream/loam/intake/dga/Annotation.scala
@@ -254,7 +254,7 @@ object Annotation {
       val annotationMethodPart: Option[JField] = annotationMethod.map("method" -> JString(_))
       
       val fields: Seq[JField] = Seq(
-        "sources" -> JArray(this.sources.toList.map(_.toJson))
+        "sources" -> JArray(this.sources.to(List).map(_.toJson))
       ) ++ annotationMethodPart
       
       JObject(fields: _*)

--- a/src/main/scala/loamstream/loam/intake/dga/Annotation.scala
+++ b/src/main/scala/loamstream/loam/intake/dga/Annotation.scala
@@ -9,6 +9,7 @@ import loamstream.util.Tries
 import scala.util.Success
 import loamstream.util.LogContext
 import org.json4s._
+import scala.collection.compat._
 
 /**
  * @author clint
@@ -90,7 +91,7 @@ object Annotation {
       annotationId: String, 
       json: JValue)(implicit ctx: LogContext): Try[Seq[Download]] = {
     
-    allFileDownloads(json).map(_.filter(isValidDownload(annotationId)).toSeq.sortBy(_.md5Sum))
+    allFileDownloads(json).map(_.filter(isValidDownload(annotationId)).to(Seq).sortBy(_.md5Sum))
   }
   
   def fromJson(

--- a/src/main/scala/loamstream/loam/intake/dga/Json.scala
+++ b/src/main/scala/loamstream/loam/intake/dga/Json.scala
@@ -9,6 +9,8 @@ import org.json4s.jackson.JsonMethods.render
 
 import loamstream.util.Tries
 
+import scala.collection.compat._
+
 /**
  * @author clint
  * Jan 20, 2021
@@ -28,14 +30,14 @@ object Json {
       case b: Boolean => b
       case None => JNull
       case Some(value) => toJValue(value)
-      case as: Seq[_] => JArray(as.map(toJValue(_)).toList)
+      case as: Seq[_] => JArray(as.map(toJValue(_)).to(List))
       case _ => sys.error(s"Unexpected ${a.getClass.getName} value '${a}'")
     }
   }
   
   def toJValue[A](oa: Option[A]): JValue = oa.map(toJValue(_)).getOrElse(JNull)
   
-  def toJValue[A](as: Seq[A])(implicit discriminator: DummyImplicit): JValue = JArray(as.toList.map(toJValue(_)))
+  def toJValue[A](as: Seq[A])(implicit discriminator: DummyImplicit): JValue = JArray(as.to(List).map(toJValue(_)))
   
   implicit final class JsonOps(val jv: JValue) extends AnyVal {
     private def makeMessage(tpe: String, fieldName: String): String = {

--- a/src/main/scala/loamstream/loam/intake/metrics/SummaryStats.scala
+++ b/src/main/scala/loamstream/loam/intake/metrics/SummaryStats.scala
@@ -32,7 +32,7 @@ final case class SummaryStats(
   def percentComplemented: Double = toPercent(fractionComplemented)
   
   def chromosomesWithNoValidVariants: Set[String] = {
-    validVariantsByChromosome.collect { case (chrom, 0) => chrom }.toSet
+    validVariantsByChromosome.collect { case (chrom, 0) => chrom }.to(Set)
   }
   
   def toFileContents: String = {

--- a/src/main/scala/loamstream/loam/intake/metrics/SummaryStats.scala
+++ b/src/main/scala/loamstream/loam/intake/metrics/SummaryStats.scala
@@ -1,5 +1,7 @@
 package loamstream.loam.intake.metrics
 
+import scala.collection.compat._
+
 final case class SummaryStats(
     validVariants: Int, //valid, ie, not skipped
     skippedVariants: Int,
@@ -60,8 +62,8 @@ Skipped: ${skippedVariants} (${percentSkipped} %)
 Flipped: ${flippedVariants} (${percentFlipped} %)
 Complemented: ${complementedVariants} (${percentComplemented} %)
 Counts by chromosome: 
-${validVariantsByChromosome.toSeq.sortBy(paddedChromName).map(tupleToString).mkString(System.lineSeparator)}
-Chromosomes with no variants: ${chromosomesWithNoValidVariants.toSeq.sortBy(padChromName).mkString(",")}
+${validVariantsByChromosome.to(Seq).sortBy(paddedChromName).map(tupleToString).mkString(System.lineSeparator)}
+Chromosomes with no variants: ${chromosomesWithNoValidVariants.to(Seq).sortBy(padChromName).mkString(",")}
 """.stripMargin.trim
   }
 }

--- a/src/main/scala/loamstream/model/Tool.scala
+++ b/src/main/scala/loamstream/model/Tool.scala
@@ -2,8 +2,12 @@ package loamstream.model
 
 import java.nio.file.Path
 
-import loamstream.loam.{LoamGraph, LoamProjectContext, LoamScriptContext}
+import loamstream.loam.LoamGraph
+import loamstream.loam.LoamProjectContext
+import loamstream.loam.LoamScriptContext
 import loamstream.model.Tool.DefaultStores
+
+import scala.collection.compat._
 
 /**
   * @author Clint
@@ -39,7 +43,7 @@ trait Tool extends LId.HasId {
 
   /** Adds input stores to this tool */
   def in(inStores: Iterable[Store]): this.type = {
-    projectContext.updateGraph(_.withInputStores(this, inStores.toSet))
+    projectContext.updateGraph(_.withInputStores(this, inStores.to(Set)))
     
     this
   }
@@ -49,7 +53,7 @@ trait Tool extends LId.HasId {
 
   /** Adds output stores to this tool */
   def out(outStores: Iterable[Store]): this.type = {
-    projectContext.updateGraph(_.withOutputStores(this, outStores.toSet))
+    projectContext.updateGraph(_.withOutputStores(this, outStores.to(Set)))
     
     this
   }
@@ -95,7 +99,7 @@ object Tool {
 
   final case class InputsAndOutputs(inputs: Iterable[Store],
                                     outputs: Iterable[Store]) extends DefaultStores {
-    override def all: Set[Store] = (inputs ++ outputs).toSet
+    override def all: Set[Store] = (inputs ++ outputs).to(Set)
   }
 
   object InputsAndOutputs {

--- a/src/main/scala/loamstream/model/execute/AsyncLocalChunkRunner.scala
+++ b/src/main/scala/loamstream/model/execute/AsyncLocalChunkRunner.scala
@@ -28,7 +28,7 @@ final case class AsyncLocalChunkRunner(
   import AsyncLocalChunkRunner._
   
   override def run(
-      jobs: Set[LJob], 
+      jobs: Iterable[LJob], 
       jobOracle: JobOracle): Observable[(LJob, RunData)] = {
     
     if(jobs.isEmpty) { Observable.empty }

--- a/src/main/scala/loamstream/model/execute/AsyncLocalChunkRunner.scala
+++ b/src/main/scala/loamstream/model/execute/AsyncLocalChunkRunner.scala
@@ -15,6 +15,7 @@ import loamstream.util.Observables
 import loamstream.util.Throwables
 import loamstream.util.ThisMachine
 import monix.reactive.Observable
+import scala.collection.compat._
 
 /**
  * @author clint
@@ -43,7 +44,7 @@ final case class AsyncLocalChunkRunner(
         Observable.from(executeSingle(executionConfig, jobOracle, job))
       }
 
-      val executionObservables: Seq[Observable[RunData]] = jobs.toSeq.map(exec)
+      val executionObservables: Seq[Observable[RunData]] = jobs.to(Seq).map(exec)
         
       Observables.merge(executionObservables).map(runData => (runData.job -> runData))
     }

--- a/src/main/scala/loamstream/model/execute/AsyncLocalChunkRunner.scala
+++ b/src/main/scala/loamstream/model/execute/AsyncLocalChunkRunner.scala
@@ -13,8 +13,8 @@ import loamstream.util.ProcessLoggers
 import loamstream.util.Loggable
 import loamstream.util.Observables
 import loamstream.util.Throwables
-import rx.lang.scala.Observable
 import loamstream.util.ThisMachine
+import monix.reactive.Observable
 
 /**
  * @author clint

--- a/src/main/scala/loamstream/model/execute/ChunkRunner.scala
+++ b/src/main/scala/loamstream/model/execute/ChunkRunner.scala
@@ -14,7 +14,7 @@ import monix.reactive.Observable
 trait ChunkRunner extends Terminable {
   def canRun(job: LJob): Boolean
   
-  def run(jobs: Set[LJob], jobOracle: JobOracle): Observable[(LJob, RunData)]
+  def run(jobs: Iterable[LJob], jobOracle: JobOracle): Observable[(LJob, RunData)]
   
   override def stop(): Unit = ()
 }

--- a/src/main/scala/loamstream/model/execute/ChunkRunner.scala
+++ b/src/main/scala/loamstream/model/execute/ChunkRunner.scala
@@ -4,7 +4,8 @@ import loamstream.model.jobs.JobOracle
 import loamstream.model.jobs.LJob
 import loamstream.model.jobs.RunData
 import loamstream.util.Terminable
-import rx.lang.scala.Observable
+import monix.reactive.Observable
+
 
 /**
  * @author clint

--- a/src/main/scala/loamstream/model/execute/CompositeChunkRunner.scala
+++ b/src/main/scala/loamstream/model/execute/CompositeChunkRunner.scala
@@ -17,12 +17,12 @@ final case class CompositeChunkRunner(components: Seq[ChunkRunner]) extends Chun
   override def canRun(job: LJob): Boolean = components.exists(_.canRun(job))
   
   override def run(
-      jobs: Set[LJob], 
+      jobs: Iterable[LJob], 
       jobOracle: JobOracle): Observable[(LJob, RunData)] = {
     
     require(jobs.forall(canRun), s"Don't know how to run ${jobs.filterNot(canRun)}")
     
-    val byRunner: Iterable[(ChunkRunner, Set[LJob])] = components.map { runner => 
+    val byRunner: Iterable[(ChunkRunner, Iterable[LJob])] = components.map { runner => 
       runner -> jobs.filter(runner.canRun) 
     }
     

--- a/src/main/scala/loamstream/model/execute/CompositeChunkRunner.scala
+++ b/src/main/scala/loamstream/model/execute/CompositeChunkRunner.scala
@@ -6,7 +6,7 @@ import loamstream.model.jobs.RunData
 import loamstream.util.Loggable
 import loamstream.util.Observables
 import loamstream.util.Throwables
-import rx.lang.scala.Observable
+import monix.reactive.Observable
 
 /**
  * @author clint

--- a/src/main/scala/loamstream/model/execute/DbBackedExecutionRecorder.scala
+++ b/src/main/scala/loamstream/model/execute/DbBackedExecutionRecorder.scala
@@ -1,11 +1,11 @@
 package loamstream.model.execute
 
-import loamstream.util.Loggable
 import loamstream.db.LoamDao
 import loamstream.model.jobs.Execution
-import loamstream.model.jobs.LJob
 import loamstream.model.jobs.JobOracle
+import loamstream.model.jobs.LJob
 import loamstream.model.jobs.StoreRecord
+import loamstream.util.Loggable
 
 /**
  * @author clint

--- a/src/main/scala/loamstream/model/execute/DryRunner.scala
+++ b/src/main/scala/loamstream/model/execute/DryRunner.scala
@@ -9,6 +9,7 @@ import java.io.PrintWriter
 import java.io.FileWriter
 import java.nio.file.Path
 import java.time.Instant
+import scala.collection.compat._
 
 /**
  * @author clint
@@ -41,7 +42,7 @@ object DryRunner extends Loggable {
         seen += job
         
         val pathToLeaf = {
-          val inputsSortedById = jobNode.dependencies.filterNot(alreadySeen).toSeq.sortBy(jobId)
+          val inputsSortedById = jobNode.dependencies.filterNot(alreadySeen).to(Seq).sortBy(jobId)
           
           inputsSortedById.flatMap(gatherJobs)
         }
@@ -66,7 +67,7 @@ object DryRunner extends Loggable {
       }
     }
 
-    executable.jobNodes.toSeq.sortBy(jobId).flatMap(gatherJobs)
+    executable.jobNodes.to(Seq).sortBy(jobId).flatMap(gatherJobs)
   }
   
   private def jobId(jn: JobNode) = jn.job.id

--- a/src/main/scala/loamstream/model/execute/Executable.scala
+++ b/src/main/scala/loamstream/model/execute/Executable.scala
@@ -3,7 +3,7 @@ package loamstream.model.execute
 import loamstream.model.jobs.JobNode
 import loamstream.model.jobs.LJob
 import loamstream.util.Observables
-import rx.lang.scala.Observable
+import monix.reactive.Observable
 
 /** A container of jobs to be executed */
 final case class Executable(jobNodes: Set[JobNode]) {

--- a/src/main/scala/loamstream/model/execute/ExecuterHelpers.scala
+++ b/src/main/scala/loamstream/model/execute/ExecuterHelpers.scala
@@ -20,6 +20,7 @@ import loamstream.util.Functions
 import scala.util.Try
 import loamstream.util.FileMonitor
 import scala.util.control.NonFatal
+import scala.collection.compat._
 
 /**
  * @author clint
@@ -65,7 +66,7 @@ object ExecuterHelpers extends Loggable {
     val anyMissingOutputs = job.outputs.exists(_.isMissing)
     
     if(anyMissingOutputs) {
-      val missingOutputs = job.outputs.toSeq.filter(_.isMissing)
+      val missingOutputs = job.outputs.to(Seq).filter(_.isMissing)
       
       error(s"Will wait for these missing outputs for job ${job.id} : ${missingOutputs}")
       

--- a/src/main/scala/loamstream/model/execute/ExecutionState.scala
+++ b/src/main/scala/loamstream/model/execute/ExecutionState.scala
@@ -166,7 +166,7 @@ final class ExecutionState private (
   
   private def transition(jobs: TraversableOnce[LJob], doTransition: JobExecutionState => JobExecutionState): Unit = {
     if(jobs.nonEmpty) {
-      val jobSet = jobs.toSet
+      val jobSet = jobs.to(Set)
       
       jobStatesBox.foreach { jobStates =>
         val jobIndices: Iterator[Int] = jobSet.iterator.map(index.get(_))
@@ -238,7 +238,7 @@ final class ExecutionState private (
    */
   private[execute] def cancelSuccessors(failedJob: LJob): Unit = {
     TimeUtils.time(s"Cancelling successors for failed job with id ${failedJob.id}", debug(_)) {
-      val successors = ExecuterHelpers.flattenTree(Set(failedJob), _.successors).toSet - failedJob
+      val successors = ExecuterHelpers.flattenTree(Set(failedJob), _.successors).to(Set) - failedJob
       
       markAs(successors.iterator.map(_.job), JobStatus.CouldNotStart)
     }

--- a/src/main/scala/loamstream/model/execute/ExecutionState.scala
+++ b/src/main/scala/loamstream/model/execute/ExecutionState.scala
@@ -10,6 +10,7 @@ import loamstream.util.ValueBox
 import loamstream.util.TimeUtils
 import loamstream.util.Sequence
 import cats.kernel.Eq
+import scala.collection.compat._
 
 /**
  * @author clint
@@ -108,7 +109,7 @@ final class ExecutionState private (
         
         def anyDepsStopExecution: Boolean = {
           //Profiler-guided optimization: mapping over a Set is slow enough that we convert to a Seq first here.
-          def depStates = statesFor(jobStates)(job.dependencies.toSeq.map(_.job)) 
+          def depStates = statesFor(jobStates)(job.dependencies.to(Seq).map(_.job)) 
           
           jobState.notStarted && depStates.exists(_.canStopExecution)
         }

--- a/src/main/scala/loamstream/model/execute/ExecutionState.scala
+++ b/src/main/scala/loamstream/model/execute/ExecutionState.scala
@@ -9,6 +9,7 @@ import loamstream.util.Loggable
 import loamstream.util.ValueBox
 import loamstream.util.TimeUtils
 import loamstream.util.Sequence
+import cats.kernel.Eq
 
 /**
  * @author clint
@@ -283,5 +284,7 @@ object ExecutionState {
   
   object JobStatuses {
     val empty: JobStatuses = JobStatuses(Set.empty, Set.empty, 0, 0)
+    
+    implicit val eqJobStatuses: Eq[JobStatuses] = Eq.fromUniversalEquals
   }
 }

--- a/src/main/scala/loamstream/model/execute/MissingOutputsJobFilter.scala
+++ b/src/main/scala/loamstream/model/execute/MissingOutputsJobFilter.scala
@@ -2,6 +2,7 @@ package loamstream.model.execute
 
 import loamstream.model.jobs.LJob
 import loamstream.util.Loggable
+import scala.collection.compat._
 
 /**
  * @author clint
@@ -12,7 +13,7 @@ object MissingOutputsJobFilter extends JobFilter with Loggable {
     val jobShouldRun = job.outputs.isEmpty || job.outputs.exists(_.isMissing)
     
     if(jobShouldRun) {
-      def missingOutputs: Seq[String] = job.outputs.filter(_.isMissing).map(_.location).toSeq.map(l => s"'${l}'")
+      def missingOutputs: Seq[String] = job.outputs.filter(_.isMissing).map(_.location).to(Seq).map(l => s"'${l}'")
       
       debug(s"Running job $job because these outputs are missing: ${missingOutputs.mkString(",")}")
     } else {

--- a/src/main/scala/loamstream/model/execute/ProtectsFilesJobCanceler.scala
+++ b/src/main/scala/loamstream/model/execute/ProtectsFilesJobCanceler.scala
@@ -49,7 +49,7 @@ final class ProtectsFilesJobCanceler private (
     case _ => false
   }
   
-  private[execute] def locationsToProtect: Set[String] = _locationsToProtect.asScala.toSet
+  private[execute] def locationsToProtect: Set[String] = _locationsToProtect.asScala.to(Set)
   
   override def shouldCancel(job: LJob): Boolean = {
     def isProtected(output: DataHandle): Boolean = _locationsToProtect.contains(output.location)

--- a/src/main/scala/loamstream/model/execute/ProtectsFilesJobCanceler.scala
+++ b/src/main/scala/loamstream/model/execute/ProtectsFilesJobCanceler.scala
@@ -121,6 +121,6 @@ object ProtectsFilesJobCanceler {
     
     val locs = lines.map(_.trim).filterNot(shouldSkip).map(parse)
     
-    fromEithers(locs.toList)
+    fromEithers(locs.to(List))
   }
 }

--- a/src/main/scala/loamstream/model/execute/ProtectsFilesJobCanceler.scala
+++ b/src/main/scala/loamstream/model/execute/ProtectsFilesJobCanceler.scala
@@ -15,6 +15,7 @@ import loamstream.util.CanBeClosed
 import loamstream.util.Loggable
 import loamstream.util.{Paths => LPaths}
 import java.nio.file.Paths
+import scala.collection.compat._
 
 /**
  * @author clint
@@ -33,7 +34,7 @@ final class ProtectsFilesJobCanceler private (
     debug(s"Made ${ProtectsFilesJobCanceler.getClass.getSimpleName} that will protect ${size} locations:")
     
     if(isDebugEnabled) {
-      locationsToProtect.toSeq.sorted.foreach(debug(_))
+      locationsToProtect.to(Seq).sorted.foreach(debug(_))
     }
   }
   

--- a/src/main/scala/loamstream/model/execute/RxExecuter.scala
+++ b/src/main/scala/loamstream/model/execute/RxExecuter.scala
@@ -26,6 +26,8 @@ import scala.concurrent.duration.FiniteDuration
 import monix.reactive.OverflowStrategy
 import monix.reactive.observers.Subscriber
 
+import scala.collection.compat._
+
 
 /**
  * @author kaan
@@ -48,7 +50,7 @@ final case class RxExecuter(
   require(maxRunsPerJob >= 1, s"The maximum number of times to run each job must not be negative; got $maxRunsPerJob")
 
   protected override val terminableComponents: Iterable[Terminable] = {
-    additionalTerminableComponents.toSet + executionRecorder
+    additionalTerminableComponents.to(Set) + executionRecorder
   }
   
   import executionRecorder.record
@@ -224,7 +226,7 @@ final case class RxExecuter(
     
     if(jobsToRun.isEmpty) { Observable(None) }
     else {
-      val jobRunObs = runner.run(jobsToRun.toSet, jobOracle)
+      val jobRunObs = runner.run(jobsToRun.to(Set), jobOracle)
       
       jobRunObs.flatMap(toExecutionMap(fileMonitor)).map(Option(_))
     }

--- a/src/main/scala/loamstream/model/execute/RxExecuter.scala
+++ b/src/main/scala/loamstream/model/execute/RxExecuter.scala
@@ -79,8 +79,10 @@ final case class RxExecuter(
     
     propagateExecutionStateOnException(executionState) {
       val jobResultTuples: Observable[(LJob, Execution)] = {
-        //Note onBackpressureDrop(), in case runEligibleJobs takes too long (or the polling window is too short)
-        val ticks = Observable.interval(windowLength).asyncBoundary(Observables.defaultOverflowStrategy).executeOn(scheduler)
+        val ticks = Observable
+                      .interval(windowLength)
+                      .asyncBoundary(Observables.defaultOverflowStrategy)
+                      .executeOn(scheduler)
         
         def runJobs(jobsAndCells: ExecutionState.JobStatuses) = runEligibleJobs(executionState, jobOracle, jobsAndCells)
         

--- a/src/main/scala/loamstream/model/jobs/Execution.scala
+++ b/src/main/scala/loamstream/model/jobs/Execution.scala
@@ -18,6 +18,7 @@ import loamstream.model.execute.GoogleSettings
 import loamstream.model.execute.UgerDrmSettings
 import loamstream.model.execute.LsfDrmSettings
 import loamstream.model.execute.AwsSettings
+import scala.collection.compat._
 
 /**
  * @author clint
@@ -174,10 +175,10 @@ object Execution extends Loggable {
   }
   
   private def toStoreRecords(dataHandles: Iterable[DataHandle]): Iterable[StoreRecord] = {
-    //Note .toSeq here.  This prevents building a set of StoreRecords (as long as job.outputs is a Set),
+    //Note .to(Seq) here.  This prevents building a set of StoreRecords (as long as job.outputs is a Set),
     //which would invoke StoreRecord.equals for each StoreRecord produced, forcing the evaluation of thos
     //StoreRecords' hash fields.  We want to prevent forcing the evaluation of those fields and leave the
     //the decision to hash or not to ExecutionRecorders. (Ie, don't eval hashes if they won't be used.) 
-    dataHandles.toSeq.map(_.toStoreRecord)
+    dataHandles.to(Seq).map(_.toStoreRecord)
   }
 }

--- a/src/main/scala/loamstream/model/jobs/Execution.scala
+++ b/src/main/scala/loamstream/model/jobs/Execution.scala
@@ -69,7 +69,7 @@ final case class Execution(
   def withStoreRecords(newOutputs: Set[StoreRecord]): Execution = copy(outputs = newOutputs)
   
   def withStoreRecords(newOutput: StoreRecord, others: StoreRecord*): Execution = {
-    withStoreRecords((newOutput +: others).toSet)
+    withStoreRecords((newOutput +: others).to(Set))
   }
 
   def withResources(rs: Resources): Execution = copy(resources = Some(rs))

--- a/src/main/scala/loamstream/model/jobs/JobNode.scala
+++ b/src/main/scala/loamstream/model/jobs/JobNode.scala
@@ -1,16 +1,6 @@
 package loamstream.model.jobs
 
-import loamstream.util.ValueBox
-import rx.lang.scala.Subject
-import rx.lang.scala.subjects.ReplaySubject
-import rx.lang.scala.Observable
 import loamstream.util.Loggable
-import loamstream.util.Observables
-import rx.lang.scala.observables.ConnectableObservable
-import rx.lang.scala.subjects.BehaviorSubject
-import rx.lang.scala.subjects.SerializedSubject
-import loamstream.model.jobs.log.JobLog
-import rx.lang.scala.subjects.PublishSubject
 
 /**
  * @author oliverr

--- a/src/main/scala/loamstream/model/jobs/JobStatus.scala
+++ b/src/main/scala/loamstream/model/jobs/JobStatus.scala
@@ -2,6 +2,7 @@ package loamstream.model.jobs
 
 import loamstream.util.Loggable
 import loamstream.util.ExitCodes
+import scala.collection.compat._
 
 /**
  * @author kyuksel
@@ -51,7 +52,7 @@ object JobStatus extends Loggable {
   case object Canceled extends NeitherSuccessNorFailure(isTerminal = true)
   case object FailedPermanently extends Failure(isTerminal = true)
 
-  def values: Set[JobStatus] = namesToInstances.values.toSet
+  def values: Set[JobStatus] = namesToInstances.values.to(Set)
   
   def fromString(s: String): Option[JobStatus] = namesToInstances.get(s.toLowerCase.trim)
 

--- a/src/main/scala/loamstream/model/jobs/LJob.scala
+++ b/src/main/scala/loamstream/model/jobs/LJob.scala
@@ -2,17 +2,8 @@ package loamstream.model.jobs
 
 import java.nio.file.Path
 
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
-
-import loamstream.util.Loggable
-import loamstream.util.Observables
-import loamstream.util.ValueBox
-import rx.lang.scala.Observable
-import rx.lang.scala.Subject
-import rx.lang.scala.subjects.ReplaySubject
-import loamstream.util.Sequence
 import loamstream.model.execute.Settings
+import loamstream.util.Sequence
 
 /**
  * @author oliverr

--- a/src/main/scala/loamstream/util/CommandInvoker.scala
+++ b/src/main/scala/loamstream/util/CommandInvoker.scala
@@ -108,7 +108,7 @@ object CommandInvoker {
   object Async {
     final class JustOnce[A](
       val binaryName: String,
-      delegateFn: InvocationFn[A])(implicit ec: Scheduler, logCtx: LogContext) extends CommandInvoker.Async[A] {
+      delegateFn: InvocationFn[A])(implicit scheduler: Scheduler, logCtx: LogContext) extends CommandInvoker.Async[A] {
 
       override def apply(param: A): Future[RunResults.Successful] = {
         import Observables.Implicits._

--- a/src/main/scala/loamstream/util/Iterators.scala
+++ b/src/main/scala/loamstream/util/Iterators.scala
@@ -1,5 +1,7 @@
 package loamstream.util
 
+import scala.collection.compat._
+
 /**
  * @author clint
  * Sep 25, 2017
@@ -13,7 +15,7 @@ object Iterators {
   }
   
   def sample[A](as: Iterator[A], indices: Seq[Int]): Iterator[A] = {
-    val indicesSet = indices.toSet
+    val indicesSet = indices.to(Set)
 
     as.zipWithIndex.collect { case (a, i) if indicesSet.contains(i) => a }
   }

--- a/src/main/scala/loamstream/util/Loops.scala
+++ b/src/main/scala/loamstream/util/Loops.scala
@@ -70,9 +70,7 @@ object Loops {
     
     val delays = Backoff.delaySequence(delayStart, delayCap)
     
-    def delayAndThen[X](f: => X): Observable[X] = {
-      Observable.interval(delays.next()).drop(1).take(1).subscribeOn(scheduler).map(_ => f)
-    }
+    def delayAndThen[X](f: => X): Observable[X] = Observable.evalDelayed(delays.next(), f)
     
     def next(tuple: (Int, Observable[Try[A]])): Observable[(Int, Try[A])] = {
       val (i, attemptObs) = tuple

--- a/src/main/scala/loamstream/util/Loops.scala
+++ b/src/main/scala/loamstream/util/Loops.scala
@@ -8,11 +8,10 @@ import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
 
-import rx.lang.scala.Observable
-import rx.lang.scala.schedulers.IOScheduler
-import rx.lang.scala.Scheduler
-
 import scala.language.higherKinds
+import monix.reactive.Observable
+import monix.execution.Scheduler
+import scala.concurrent.duration.FiniteDuration
 
 /**
  * @author clint
@@ -21,7 +20,7 @@ import scala.language.higherKinds
 object Loops {
   
   private[util] object Backoff {
-    def delaySequence(start: Duration, cap: Duration): Iterator[Duration] = {
+    def delaySequence(start: FiniteDuration, cap: FiniteDuration): Iterator[FiniteDuration] = {
       require(start gt 0.seconds)
       require(cap gt 0.seconds)
       
@@ -37,8 +36,8 @@ object Loops {
    */
   def retryUntilSuccessWithBackoff[A](
       maxRuns: Int, 
-      delayStart: Duration, 
-      delayCap: Duration)(op: => Try[A]): Option[A] = {
+      delayStart: FiniteDuration, 
+      delayCap: FiniteDuration)(op: => Try[A]): Option[A] = {
     
     val delays = Backoff.delaySequence(delayStart, delayCap)
     
@@ -65,13 +64,15 @@ object Loops {
   
   def retryUntilSuccessWithBackoffAsync[A](
       maxRuns: Int, 
-      delayStart: Duration, 
-      delayCap: Duration,
+      delayStart: FiniteDuration, 
+      delayCap: FiniteDuration,
       scheduler: Scheduler)(op: => Observable[Try[A]]): Observable[Option[A]] = {
     
     val delays = Backoff.delaySequence(delayStart, delayCap)
     
-    def delayAndThen[X](f: => X): Observable[X] = Observable.timer(delays.next(), scheduler).map(_ => f)
+    def delayAndThen[X](f: => X): Observable[X] = {
+      Observable.interval(delays.next()).drop(1).take(1).subscribeOn(scheduler).map(_ => f)
+    }
     
     def next(tuple: (Int, Observable[Try[A]])): Observable[(Int, Try[A])] = {
       val (i, attemptObs) = tuple
@@ -84,9 +85,11 @@ object Loops {
     }
     
     if(maxRuns == 0) { 
-      Observable.just(None)
+      Observable(None)
     } else {
-      next(1 -> op).collect { case (_, attempt) => attempt.toOption }.headOption.map(_.flatten)
+      import Observables.Implicits._
+      
+      next(1 -> op).collect { case (_, attempt) => attempt.toOption }.firstOption.map(_.flatten)
     }
   }
 }

--- a/src/main/scala/loamstream/util/Observables.scala
+++ b/src/main/scala/loamstream/util/Observables.scala
@@ -128,11 +128,11 @@ object Observables extends Loggable {
       def until(p: A => Boolean): Observable[A] = obs.takeWhileInclusive(!p(_))
       
       def firstOption: Observable[Option[A]] = {
-        obs.isEmpty.flatMap(isEmpty => if(isEmpty) Observable.empty else obs.map(Option(_)).take(1))
+        obs.isEmpty.flatMap(isEmpty => if(isEmpty) Observable(None) else obs.map(Option(_)).take(1))
       }
       
       def lastOption: Observable[Option[A]] = {
-        obs.isEmpty.flatMap(isEmpty => if(isEmpty) Observable.empty else obs.last.map(Option(_)))
+        obs.isEmpty.flatMap(isEmpty => if(isEmpty) Observable(None) else obs.last.map(Option(_)))
       }
       
       /**

--- a/src/main/scala/loamstream/util/Observables.scala
+++ b/src/main/scala/loamstream/util/Observables.scala
@@ -10,6 +10,7 @@ import scala.concurrent.duration.Duration
 import monix.reactive.Observable
 import monix.execution.Scheduler
 import monix.execution.Ack
+import monix.reactive.Observer
 
 /**
  * @author clint
@@ -18,28 +19,6 @@ import monix.execution.Ack
  * An object to hold utility methods operating on Observables
  */
 object Observables extends Loggable {
-  /**
-   * Turn a Seq of Observables into an Observable that produces Seqs, a la Future.sequence.
-   * 
-   * If the input Seq is empty, return an Observable that will immediately fire Nil to all subscribers.
-   * Otherwise, return the result of Observable.zip(os)
-   * 
-   * @param os: the sequence of observables to transform
-   * @see Observable.zip 
-   * 
-   * Note that this method takes a Seq and returns an Observable[Seq[A]].  Making the return type depend
-   * on the param type, like Future.sequence, is possible but inconvenient due to the signature of 
-   * Observable.zip(), the method this one delegates most of its work to.
-   */
-  def sequence[A](os: Seq[Observable[A]]): Observable[Seq[A]] = {
-    if (os.isEmpty) { Observable(Nil) }
-    else {
-      //Observable.zip(Observable.from(os))
-      
-      ???
-    }
-  }
-  
   /**
    * Runs a chunk of code asynchronously via the supplied ExecutionContext, and returns an
    * Observable that will fire (and then complete) when the code chunk finishes running.
@@ -146,7 +125,7 @@ object Observables extends Loggable {
        * NB: Note that this was renamed to 'until' from 'takeUntil'.  The latter would be preferrable, but it conflicts
        * with a method in RxScala proper.
        */
-      def until(p: A => Boolean): Observable[A] = obs.takeWhileInclusive(p)
+      def until(p: A => Boolean): Observable[A] = obs.takeWhileInclusive(!p(_))
       
       def firstOption: Observable[Option[A]] = {
         obs.isEmpty.flatMap(isEmpty => if(isEmpty) Observable.empty else obs.map(Option(_)).take(1))

--- a/src/main/scala/loamstream/util/RxSchedulers.scala
+++ b/src/main/scala/loamstream/util/RxSchedulers.scala
@@ -1,9 +1,7 @@
 package loamstream.util
 
-import rx.lang.scala.Scheduler
-import rx.schedulers.Schedulers
 import scala.concurrent.ExecutionContext
-import rx.lang.scala.schedulers.ExecutionContextScheduler
+import monix.execution.Scheduler
 
 /**
  * @author clint
@@ -13,7 +11,7 @@ object RxSchedulers {
   def backedByThreadPool(numThreads: Int): (Scheduler, Terminable) = {
     val (ec, handle) = ExecutionContexts.threadPool(numThreads)
     
-    val scheduler: Scheduler = ExecutionContextScheduler(ec)
+    val scheduler: Scheduler = Scheduler(ec)
     
     scheduler -> handle
   }

--- a/src/main/scala/loamstream/util/Traversables.scala
+++ b/src/main/scala/loamstream/util/Traversables.scala
@@ -1,5 +1,7 @@
 package loamstream.util
 
+import scala.collection.compat._
+
 /**
  * @author clint
  * date: Aug 11, 2016
@@ -28,7 +30,7 @@ object Traversables {
         override def hasNext: Boolean = itr.hasNext
         
         override def next(): List[A] = {
-          try { itr.takeWhile(a => !p(a)).toList }
+          try { itr.takeWhile(a => !p(a)).to(List) }
           finally { itr.dropWhile(p) }
         }
       }.filter(_.nonEmpty)

--- a/src/main/scala/loamstream/util/Versions.scala
+++ b/src/main/scala/loamstream/util/Versions.scala
@@ -5,6 +5,7 @@ import java.util.Properties
 import java.time.Instant
 import java.io.Reader
 import java.io.InputStreamReader
+import scala.collection.compat._
 
 /**
  * @author clint
@@ -71,7 +72,7 @@ object Versions {
       Options.toTry(Option(props.getProperty(key)).map(_.trim).filter(_.nonEmpty)) {
         import scala.collection.JavaConverters._
         
-        val sortedPropKvPairs = props.asScala.toSeq.sortBy { case (k, _) => k }
+        val sortedPropKvPairs = props.asScala.to(Seq).sortBy { case (k, _) => k }
         
         s"property key '$key' not found in $sortedPropKvPairs"
       }

--- a/src/main/scala/loamstream/util/jvm/JvmArgs.scala
+++ b/src/main/scala/loamstream/util/jvm/JvmArgs.scala
@@ -5,6 +5,7 @@ import java.lang.management.ManagementFactory
 import java.nio.file.Paths
 import java.nio.file.Path
 import loamstream.cli.Conf
+import scala.collection.compat._
 
 /**
  * @author clint
@@ -23,7 +24,7 @@ final case class JvmArgs(jvmArgs: Seq[String], classpath: String) {
   }
   
   def rerunCommandTokens(conf: Conf.Values, systemProperties: Map[String, String]): Seq[String] = {
-    val sysprops = systemProperties.toSeq.sortBy { case (k, _) => k }.map { case (k, v) => s"-D${k}=${v}" }
+    val sysprops = systemProperties.to(Seq).sortBy { case (k, _) => k }.map { case (k, v) => s"-D${k}=${v}" }
     
     Seq(javaBinary.toString) ++
     jvmArgs ++ 

--- a/src/test/scala/loamstream/ExecutionResumptionEndToEndTest.scala
+++ b/src/test/scala/loamstream/ExecutionResumptionEndToEndTest.scala
@@ -40,6 +40,7 @@ import loamstream.conf.LsSettings
 import loamstream.model.jobs.JobStatus
 import loamstream.model.jobs.JobResult
 import loamstream.model.execute.HashingStrategy
+import scala.collection.compat._
 
 
 
@@ -353,7 +354,7 @@ final class ExecutionResumptionEndToEndTest extends FunSuite with ProvidesSlickL
   }
 
   private def allJobsFrom(executable: Executable): Seq[JobNode] = {
-    ExecuterHelpers.flattenTree(executable.jobNodes).toSeq
+    ExecuterHelpers.flattenTree(executable.jobNodes).to(Seq)
   }
 
   private def jobThatWritesTo(executable: Executable)(fileNameSuffix: Path): Option[LJob] = {

--- a/src/test/scala/loamstream/LoamTestHelpers.scala
+++ b/src/test/scala/loamstream/LoamTestHelpers.scala
@@ -5,7 +5,7 @@ import java.nio.file.Paths
 
 import loamstream.compiler.LoamCompiler
 import loamstream.compiler.LoamProject
-import loamstream.loam.LoamProjectContext
+import loamstream.conf.LsSettings
 import loamstream.loam.LoamScript
 import loamstream.loam.LoamToolBox
 import loamstream.model.execute.Executable
@@ -13,7 +13,8 @@ import loamstream.model.execute.RxExecuter
 import loamstream.model.jobs.Execution
 import loamstream.model.jobs.LJob
 import loamstream.util.Loggable
-import loamstream.conf.LsSettings
+
+import scala.collection.compat._
 
 
 /**
@@ -27,7 +28,7 @@ trait LoamTestHelpers extends Loggable {
   def compile(path: Path, rest: Path*): LoamCompiler.Result = {
     def toScript(p: Path): LoamScript = LoamScript.read(p).get
     
-    val paths: Set[Path] = (path +: rest).toSet
+    val paths: Set[Path] = (path +: rest).to(Set)
     
     compile(LoamProject(TestHelpers.config, LsSettings.noCliConfig, paths.map(toScript)), throwOnError = false)
   }

--- a/src/test/scala/loamstream/TestHelpers.scala
+++ b/src/test/scala/loamstream/TestHelpers.scala
@@ -58,6 +58,7 @@ import loamstream.model.execute.EnvironmentType
 import java.time.LocalDateTime
 import java.time.ZoneId
 import loamstream.conf.LsSettings
+import scala.concurrent.duration.FiniteDuration
 
 /**
   * @author clint
@@ -290,11 +291,17 @@ object TestHelpers {
     
   def dummyOutputStreams: OutputStreams = OutputStreams(dummyFileName, dummyFileName)
   
+  val defaultWaitTime: FiniteDuration = {
+    import scala.concurrent.duration._
+    
+    10.minutes
+  }
+  
   def waitFor[A](f: Future[A]): A = {
     import scala.concurrent.duration._
 
     //NB: Hard-coded timeout. :(  But at least it's no longer infinite! :)
-    Await.result(f, 10.minutes)
+    Await.result(f, defaultWaitTime)
   }
   
   //foobar => FoObAr, etc

--- a/src/test/scala/loamstream/apps/AppWiringTest.scala
+++ b/src/test/scala/loamstream/apps/AppWiringTest.scala
@@ -29,6 +29,7 @@ import loamstream.model.execute.ProtectsFilesJobCanceler
 import loamstream.TestHelpers
 import loamstream.util.Files
 
+import scala.collection.compat._
 
 
 /**
@@ -42,7 +43,7 @@ final class AppWiringTest extends FunSuite with Matchers {
   
   private val confFileForUger = Paths.get("src/test/resources/for-uger-and-lsf.conf")
   
-  private def cliConf(argString: String): Conf = Conf(argString.split("\\s+").toSeq)
+  private def cliConf(argString: String): Conf = Conf(argString.split("\\s+").to(Seq))
   
   //TODO: Purely expedient
   private def appWiring(cli: Conf): AppWiring = {

--- a/src/test/scala/loamstream/apps/AppWiringTest.scala
+++ b/src/test/scala/loamstream/apps/AppWiringTest.scala
@@ -116,7 +116,7 @@ final class AppWiringTest extends FunSuite with Matchers {
       
       val runner = actualExecuter.runner.asInstanceOf[CompositeChunkRunner]
       
-      assert(runner.components.map(_.getClass).toSet === Set(classOf[AsyncLocalChunkRunner], classOf[DrmChunkRunner]))
+      assert(runner.components.map(_.getClass).to(Set) === Set(classOf[AsyncLocalChunkRunner], classOf[DrmChunkRunner]))
       
       import JobFilter.{AndJobFilter, OrJobFilter}
       
@@ -158,7 +158,7 @@ final class AppWiringTest extends FunSuite with Matchers {
       
       val runner = actualExecuter.runner.asInstanceOf[CompositeChunkRunner]
       
-      assert(runner.components.map(_.getClass).toSet === Set(classOf[AsyncLocalChunkRunner], classOf[DrmChunkRunner]))
+      assert(runner.components.map(_.getClass).to(Set) === Set(classOf[AsyncLocalChunkRunner], classOf[DrmChunkRunner]))
     }
     
     doTest(DrmSystem.Uger, Conf.RunStrategies.AllOf)
@@ -187,7 +187,7 @@ final class AppWiringTest extends FunSuite with Matchers {
       
       val runner = actualExecuter.runner.asInstanceOf[CompositeChunkRunner]
       
-      assert(runner.components.map(_.getClass).toSet === Set(classOf[AsyncLocalChunkRunner], classOf[DrmChunkRunner]))
+      assert(runner.components.map(_.getClass).to(Set) === Set(classOf[AsyncLocalChunkRunner], classOf[DrmChunkRunner]))
       
       actualExecuter.asInstanceOf[RxExecuter].jobFilter shouldBe JobFilter.RunEverything
     }
@@ -206,7 +206,7 @@ final class AppWiringTest extends FunSuite with Matchers {
       
       val runner = actualExecuter.runner.asInstanceOf[CompositeChunkRunner]
       
-      assert(runner.components.map(_.getClass).toSet === Set(classOf[AsyncLocalChunkRunner], classOf[DrmChunkRunner]))
+      assert(runner.components.map(_.getClass).to(Set) === Set(classOf[AsyncLocalChunkRunner], classOf[DrmChunkRunner]))
       
       val drmRunner = runner.components.collectFirst { case drmRunner: DrmChunkRunner => drmRunner }.get
       

--- a/src/test/scala/loamstream/cli/ConfTest.scala
+++ b/src/test/scala/loamstream/cli/ConfTest.scala
@@ -7,6 +7,8 @@ import org.scalatest.FunSuite
 import org.scalatest.Matchers
 import java.net.URI
 import loamstream.TestHelpers
+import scala.collection.compat._
+
 
 /**
  * Created by kyuksel on 10/12/16.
@@ -255,7 +257,7 @@ final class ConfTest extends FunSuite with Matchers {
   
   test("Values.toArguments - real-world") {
     def doTest(argLine: String): Unit = {
-      val args: Seq[String] = argLine.split("\\s+").toList
+      val args: Seq[String] = argLine.split("\\s+").to(List)
     
       val conf = Conf(args)
     
@@ -271,7 +273,7 @@ final class ConfTest extends FunSuite with Matchers {
   test("Values.toArguments - --worker is added") {
     val argLine = "--conf foo.conf --backend uger --loams u.loam v.loam"
     
-    val args: Seq[String] = argLine.split("\\s+").toList
+    val args: Seq[String] = argLine.split("\\s+").to(List)
     
     val values = Conf(args).toValues
     

--- a/src/test/scala/loamstream/db/slick/TestDbOps.scala
+++ b/src/test/scala/loamstream/db/slick/TestDbOps.scala
@@ -3,14 +3,15 @@ package loamstream.db.slick
 import scala.util.Try
 
 import loamstream.TestHelpers
-import loamstream.model.jobs.Execution
-import loamstream.model.jobs.StoreRecord
-import loamstream.model.jobs.JobResult.CommandResult
-import java.nio.file.Paths
 import loamstream.model.execute.EnvironmentType
-import loamstream.model.jobs.TerminationReason
-import loamstream.model.jobs.PseudoExecution
 import loamstream.model.execute.Run
+import loamstream.model.jobs.Execution
+import loamstream.model.jobs.JobResult.CommandResult
+import loamstream.model.jobs.PseudoExecution
+import loamstream.model.jobs.StoreRecord
+import loamstream.model.jobs.TerminationReason
+
+import scala.collection.compat._
 
 /**
  * @author clint
@@ -50,7 +51,7 @@ trait TestDbOps {
     
     val commandResult = CommandResult(exitCode)
 
-    import Paths.{get => toPath}
+    import java.nio.file.Paths.{ get => toPath }
     
     val termReason = terminationReason.flatMap(TerminationReason.fromName)
     
@@ -63,7 +64,7 @@ trait TestDbOps {
         cmd = cmd,
         status = status,
         result = Option(commandResult),
-        outputs = dao.outputsFor(executionRow).toSet,
+        outputs = dao.outputsFor(executionRow).to(Set),
         jobDir = jobDir.map(toPath(_)),
         terminationReason = termReason)
   }

--- a/src/test/scala/loamstream/drm/DrmChunkRunnerTest.scala
+++ b/src/test/scala/loamstream/drm/DrmChunkRunnerTest.scala
@@ -52,6 +52,8 @@ import monix.reactive.Observable
 import monix.execution.Scheduler
 import loamstream.model.jobs.DrmJobOracle
 
+import scala.collection.compat._
+
 
 /**
  * @author clint
@@ -440,7 +442,7 @@ final class DrmChunkRunnerTest extends FunSuite {
     def doTest(drmSystem: DrmSystem): Unit = {
       val graph = makeGraph(drmSystem)
       val executable = LoamEngine.toExecutable(graph)
-      val jobs = executable.jobs.toSeq
+      val jobs = executable.jobs.to(Seq)
       
       assert(jobs.size === 2)
       
@@ -531,7 +533,7 @@ final class DrmChunkRunnerTest extends FunSuite {
      
       val (graph, tool0, tool1, tool2, tool3) = makeGraphAndTools(drmSystem)
       val executable = LoamEngine.toExecutable(graph)
-      val jobs = executable.jobs.toSeq
+      val jobs = executable.jobs.to(Seq)
       
       assert(jobs.size === 4)
       

--- a/src/test/scala/loamstream/drm/DrmChunkRunnerTest.scala
+++ b/src/test/scala/loamstream/drm/DrmChunkRunnerTest.scala
@@ -146,7 +146,7 @@ final class DrmChunkRunnerTest extends FunSuite {
     
     val mockJob = jobWrapper.commandLineJob.asInstanceOf[MockDrmJob]
     
-    Observable.from(mockJob.statusesToReturn.toList).map(status => jobWrapper -> status)
+    Observable.from(mockJob.statusesToReturn.to(List)).map(status => jobWrapper -> status)
   }
   
   test("submit - submission failure") {

--- a/src/test/scala/loamstream/drm/DrmChunkRunnerTest.scala
+++ b/src/test/scala/loamstream/drm/DrmChunkRunnerTest.scala
@@ -456,11 +456,11 @@ final class DrmChunkRunnerTest extends FunSuite {
       val mockJobSubmitter = new MockJobSubmitter
       
       val chunkRunner = makeChunkRunner(drmSystem, mockJobSubmitter)
-          
       
-      val results = {
-        chunkRunner.run(jobs.map(_.job).toSet, TestHelpers.DummyJobOracle).toListL.runSyncUnsafe(TestHelpers.defaultWaitTime).toMap
-      }
+      //TODO: We don't need to wait here, since we're only checking that run()
+      //submitted jobs properly, and that should happen synchronously before run()
+      //returns.
+      val results = chunkRunner.run(jobs.map(_.job).toSet, TestHelpers.DummyJobOracle)
       
       val actualSubmissionParams = mockJobSubmitter.params
       
@@ -556,9 +556,10 @@ final class DrmChunkRunnerTest extends FunSuite {
       
       val chunkRunner = makeChunkRunner(drmSystem, mockJobSubmitter)
           
-      val results = {
-        chunkRunner.run(jobs.map(_.job).toSet, TestHelpers.DummyJobOracle).toListL.runSyncUnsafe(TestHelpers.defaultWaitTime).toMap
-      }
+      //TODO: We don't need to wait here, since we're only checking that run()
+      //submitted jobs properly, and that should happen synchronously before run()
+      //returns.      
+      val results = chunkRunner.run(jobs.map(_.job).toSet, TestHelpers.DummyJobOracle)
       
       val actualSubmissionParams = mockJobSubmitter.params
       

--- a/src/test/scala/loamstream/drm/DrmChunkRunnerTest.scala
+++ b/src/test/scala/loamstream/drm/DrmChunkRunnerTest.scala
@@ -242,7 +242,7 @@ final class DrmChunkRunnerTest extends FunSuite {
     
     assert(TestHelpers.waitFor(runner.submit(drmSettings, taskArray).firstAsFuture) === expected)
     
-    assert(runner.submittedTaskArrayIds.toSet === Set(taskId.jobId))
+    assert(runner.submittedTaskArrayIds.to(Set) === Set(taskId.jobId))
   }
   
   test("toRunDatas - one failed job") {
@@ -463,14 +463,14 @@ final class DrmChunkRunnerTest extends FunSuite {
       //TODO: We don't need to wait here, since we're only checking that run()
       //submitted jobs properly, and that should happen synchronously before run()
       //returns.
-      val results = chunkRunner.run(jobs.map(_.job).toSet, TestHelpers.DummyJobOracle)
+      val results = chunkRunner.run(jobs.map(_.job).to(Set), TestHelpers.DummyJobOracle)
       
       val actualSubmissionParams = mockJobSubmitter.params
       
       val Seq((actualSettings, actualSubmittedJobs)) = actualSubmissionParams
       
       assert(actualSettings === expectedSettings)
-      assert(actualSubmittedJobs.drmJobs.map(_.commandLineJob).toSet === jobs.toSet)
+      assert(actualSubmittedJobs.drmJobs.map(_.commandLineJob).to(Set) === jobs.to(Set))
     }
     
     doTest(DrmSystem.Uger)
@@ -562,14 +562,14 @@ final class DrmChunkRunnerTest extends FunSuite {
       //TODO: We don't need to wait here, since we're only checking that run()
       //submitted jobs properly, and that should happen synchronously before run()
       //returns.      
-      val results = chunkRunner.run(jobs.map(_.job).toSet, TestHelpers.DummyJobOracle)
+      val results = chunkRunner.run(jobs.map(_.job).to(Set), TestHelpers.DummyJobOracle)
       
       val actualSubmissionParams = mockJobSubmitter.params
       
       val actualParamsUnordered: Set[(DrmSettings, Set[LJob])] = {
         actualSubmissionParams.map { case (settings, taskArray) => 
-          (settings, taskArray.drmJobs.map(_.commandLineJob).toSet[LJob]) 
-        }.toSet
+          (settings, taskArray.drmJobs.map(_.commandLineJob: LJob).to(Set)) 
+        }.to(Set)
       }
       
       val expectedParamsUnordered: Set[(DrmSettings, Set[LJob])] = Set(

--- a/src/test/scala/loamstream/drm/DrmChunkRunnerTest.scala
+++ b/src/test/scala/loamstream/drm/DrmChunkRunnerTest.scala
@@ -37,8 +37,6 @@ import loamstream.model.quantities.Cpus
 import loamstream.model.quantities.Memory
 import loamstream.util.Observables
 
-import rx.lang.scala.Observable
-import rx.lang.scala.schedulers.IOScheduler
 import loamstream.model.execute.LocalSettings
 import loamstream.model.execute.Settings
 import loamstream.util.ValueBox
@@ -50,6 +48,8 @@ import loamstream.model.jobs.TerminationReason
 import loamstream.model.execute.Resources.UgerResources
 import loamstream.drm.uger.QdelJobKiller
 import loamstream.model.execute.LsfDrmSettings
+import monix.reactive.Observable
+import monix.execution.Scheduler
 
 
 /**
@@ -59,12 +59,13 @@ import loamstream.model.execute.LsfDrmSettings
  */
 final class DrmChunkRunnerTest extends FunSuite {
   
-  private val scheduler = IOScheduler()
+  private val scheduler = Scheduler.io()
+  
+  import Scheduler.Implicits.global
   
   import loamstream.TestHelpers.path
   import loamstream.model.jobs.JobStatus.FailedPermanently
   import loamstream.model.jobs.JobStatus.Succeeded
-  import scala.concurrent.ExecutionContext.Implicits.global
   
   private val tempDir = TestHelpers.getWorkDir(getClass.getSimpleName) 
   
@@ -114,7 +115,7 @@ final class DrmChunkRunnerTest extends FunSuite {
         jobKiller = MockJobKiller.DoesNothing,
         sessionTracker = SessionTracker.Noop)
     
-    val result = waitFor(runner.run(Set.empty, TestHelpers.DummyJobOracle).to[Seq].firstAsFuture)
+    val result = runner.run(Set.empty, TestHelpers.DummyJobOracle).toListL.runSyncUnsafe(TestHelpers.defaultWaitTime)
     
     assert(result === Nil)
   }
@@ -133,7 +134,7 @@ final class DrmChunkRunnerTest extends FunSuite {
         jobKiller = MockJobKiller.DoesNothing,
         sessionTracker = SessionTracker.Noop)
     
-    val result = waitFor(runner.run(Set.empty, TestHelpers.DummyJobOracle).to[Seq].firstAsFuture)
+    val result = runner.run(Set.empty, TestHelpers.DummyJobOracle).toListL.runSyncUnsafe(TestHelpers.defaultWaitTime)
     
     assert(result === Nil)
   }
@@ -142,7 +143,7 @@ final class DrmChunkRunnerTest extends FunSuite {
     
     val mockJob = jobWrapper.commandLineJob.asInstanceOf[MockDrmJob]
     
-    Observable.from(mockJob.statusesToReturn).map(status => jobWrapper -> status)
+    Observable.from(mockJob.statusesToReturn.toList).map(status => jobWrapper -> status)
   }
   
   test("submit - submission failure") {
@@ -351,7 +352,7 @@ final class DrmChunkRunnerTest extends FunSuite {
       val accountingClient = new DrmChunkRunnerTest.MockAccountingClient(
           Map.empty[DrmTaskId, AccountingInfo].withDefault(_ => bogusAccountingInfo))
       
-      val result = waitFor(toRunDatas(accountingClient, input).to[Seq].map(_.toMap).firstAsFuture)
+      val result = toRunDatas(accountingClient, input).toListL.runSyncUnsafe(TestHelpers.defaultWaitTime).toMap
       
       val goodExecution = result(workedJob)
       val badExecution = result(failedJob)
@@ -416,7 +417,7 @@ final class DrmChunkRunnerTest extends FunSuite {
             executionConfig = executionConfig,
             drmConfig = ugerConfig,
             jobSubmitter = mockJobSubmitter,
-            jobMonitor = new JobMonitor(poller = JustFailsMockPoller, scheduler = IOScheduler()),
+            jobMonitor = new JobMonitor(poller = JustFailsMockPoller, scheduler = Scheduler.io()),
             accountingClient = MockAccountingClient.NeverWorks,
             jobKiller = MockJobKiller.DoesNothing,
             sessionTracker = SessionTracker.Noop)
@@ -428,7 +429,7 @@ final class DrmChunkRunnerTest extends FunSuite {
             executionConfig = executionConfig,
             drmConfig = lsfConfig,
             jobSubmitter = mockJobSubmitter,
-            jobMonitor = new JobMonitor(poller = JustFailsMockPoller, scheduler = IOScheduler()),
+            jobMonitor = new JobMonitor(poller = JustFailsMockPoller, scheduler = Scheduler.io()),
             accountingClient = MockAccountingClient.NeverWorks,
             jobKiller = MockJobKiller.DoesNothing,
             sessionTracker = SessionTracker.Noop)
@@ -458,7 +459,7 @@ final class DrmChunkRunnerTest extends FunSuite {
           
       
       val results = {
-        waitFor(chunkRunner.run(jobs.map(_.job).toSet, TestHelpers.DummyJobOracle).to[Seq].map(_.toMap).firstAsFuture)
+        chunkRunner.run(jobs.map(_.job).toSet, TestHelpers.DummyJobOracle).toListL.runSyncUnsafe(TestHelpers.defaultWaitTime).toMap
       }
       
       val actualSubmissionParams = mockJobSubmitter.params
@@ -505,7 +506,7 @@ final class DrmChunkRunnerTest extends FunSuite {
             executionConfig = executionConfig,
             drmConfig = ugerConfig,
             jobSubmitter = mockJobSubmitter,
-            jobMonitor = new JobMonitor(poller = MockPoller(Map.empty), scheduler = IOScheduler()),
+            jobMonitor = new JobMonitor(poller = MockPoller(Map.empty), scheduler = Scheduler.io()),
             accountingClient = MockAccountingClient.NeverWorks,
             jobKiller = MockJobKiller.DoesNothing,
             sessionTracker = SessionTracker.Noop)
@@ -518,7 +519,7 @@ final class DrmChunkRunnerTest extends FunSuite {
             drmConfig = lsfConfig,
             jobSubmitter = mockJobSubmitter,
             //NB: The poller can fail, since we're not checking execution results, just config-propagation
-            jobMonitor = new JobMonitor(poller = JustFailsMockPoller, scheduler = IOScheduler()),
+            jobMonitor = new JobMonitor(poller = JustFailsMockPoller, scheduler = Scheduler.io()),
             accountingClient = MockAccountingClient.NeverWorks,
             jobKiller = MockJobKiller.DoesNothing,
             sessionTracker = SessionTracker.Noop)
@@ -556,7 +557,7 @@ final class DrmChunkRunnerTest extends FunSuite {
       val chunkRunner = makeChunkRunner(drmSystem, mockJobSubmitter)
           
       val results = {
-        waitFor(chunkRunner.run(jobs.map(_.job).toSet, TestHelpers.DummyJobOracle).to[Seq].map(_.toMap).firstAsFuture)
+        chunkRunner.run(jobs.map(_.job).toSet, TestHelpers.DummyJobOracle).toListL.runSyncUnsafe(TestHelpers.defaultWaitTime).toMap
       }
       
       val actualSubmissionParams = mockJobSubmitter.params
@@ -613,7 +614,7 @@ object DrmChunkRunnerTest {
     override def submitJobs(drmSettings: DrmSettings, taskArray: DrmTaskArray): Observable[DrmSubmissionResult] = {
       params :+= (drmSettings -> taskArray)
       
-      Observable.just(DrmSubmissionResult.SubmissionSuccess(Map.empty))
+      Observable(DrmSubmissionResult.SubmissionSuccess(Map.empty))
     }
     
     override def stop(): Unit = ()
@@ -622,7 +623,7 @@ object DrmChunkRunnerTest {
   object MockJobSubmitter {
     final case class AlwaysFails(cause: Throwable) extends JobSubmitter {
       override def submitJobs(drmSettings: DrmSettings, taskArray: DrmTaskArray): Observable[DrmSubmissionResult] = {
-        Observable.just(DrmSubmissionResult.SubmissionFailure(cause))
+        Observable(DrmSubmissionResult.SubmissionFailure(cause))
       }
       
       override def stop(): Unit = ()
@@ -630,7 +631,7 @@ object DrmChunkRunnerTest {
     
     final case class AlwaysSucceeds(toReturn: Map[DrmTaskId, DrmJobWrapper]) extends JobSubmitter {
       override def submitJobs(drmSettings: DrmSettings, taskArray: DrmTaskArray): Observable[DrmSubmissionResult] = {
-        Observable.just(DrmSubmissionResult.SubmissionSuccess(toReturn))
+        Observable(DrmSubmissionResult.SubmissionSuccess(toReturn))
       }
       
       override def stop(): Unit = ()

--- a/src/test/scala/loamstream/drm/DrmSystemTest.scala
+++ b/src/test/scala/loamstream/drm/DrmSystemTest.scala
@@ -1,20 +1,20 @@
 package loamstream.drm
 
 import org.scalatest.FunSuite
+
+import loamstream.TestHelpers
 import loamstream.drm.uger.UgerDefaults
 import loamstream.model.execute.DrmSettings
-import loamstream.model.quantities.Cpus
-import loamstream.model.quantities.Memory
-import loamstream.model.quantities.CpuTime
-import loamstream.TestHelpers
+
+import scala.collection.compat._
 
 /**
  * @author clint
  * May 25, 2018
  */
 final class DrmSystemTest extends FunSuite {
-  import DrmSystem.Uger
   import DrmSystem.Lsf
+  import DrmSystem.Uger
   
   test("defaultQueue") {
     assert(Uger.defaultQueue === Some(UgerDefaults.queue))
@@ -63,6 +63,6 @@ final class DrmSystemTest extends FunSuite {
   }
   
   test("values") {
-    assert(DrmSystem.values.toSet === Set(Uger, Lsf))
+    assert(DrmSystem.values.to(Set) === Set(Uger, Lsf))
   }
 }

--- a/src/test/scala/loamstream/drm/JobMonitorTest.scala
+++ b/src/test/scala/loamstream/drm/JobMonitorTest.scala
@@ -42,10 +42,10 @@ final class JobMonitorTest extends FunSuite {
     import Observables.Implicits._
     
     withThreadPoolScheduler(3) { scheduler =>
-      val statuses = (new JobMonitor(scheduler, poller, 9.99)).monitor(jobIds)
-    
       def futureStatuses(taskId: DrmTaskId): Seq[DrmStatus] = {
         import Scheduler.Implicits.global
+        
+        val statuses = (new JobMonitor(scheduler, poller, 9.99)).monitor(jobIds)
         
         statuses
           .collect { case (tid, status) if tid == taskId => status }

--- a/src/test/scala/loamstream/drm/MockPoller.scala
+++ b/src/test/scala/loamstream/drm/MockPoller.scala
@@ -6,7 +6,8 @@ import loamstream.conf.DrmConfig
 import loamstream.model.execute.DrmSettings
 import loamstream.util.ValueBox
 import loamstream.model.execute.Resources.DrmResources
-import rx.lang.scala.Observable
+import monix.reactive.Observable
+
 
 /**
  * @author clint

--- a/src/test/scala/loamstream/drm/MockPoller.scala
+++ b/src/test/scala/loamstream/drm/MockPoller.scala
@@ -32,7 +32,7 @@ final case class MockPoller(private val toReturn: Map[DrmTaskId, Seq[Try[DrmStat
   def isStopped: Boolean = isStoppedBox.value
   
   override def poll(oracle: DrmJobOracle)(jobIds: Iterable[DrmTaskId]): Observable[(DrmTaskId, Try[DrmStatus])] = {
-    val jobIdsToPoll = jobIds.toSet
+    val jobIdsToPoll = jobIds.to(Set)
     
     val resultsByTaskId = toReturn.filterKeys(jobIdsToPoll.contains)
     

--- a/src/test/scala/loamstream/drm/MockPoller.scala
+++ b/src/test/scala/loamstream/drm/MockPoller.scala
@@ -10,6 +10,8 @@ import monix.reactive.Observable
 
 import loamstream.model.jobs.DrmJobOracle
 
+import scala.collection.compat._
+
 /**
  * @author clint
  * date: Jul 6, 2016
@@ -35,7 +37,7 @@ final case class MockPoller(private val toReturn: Map[DrmTaskId, Seq[Try[DrmStat
     val resultsByTaskId = toReturn.filterKeys(jobIdsToPoll.contains)
     
     val pollingResults = for {
-      (tid, attempts) <- resultsByTaskId.toSeq
+      (tid, attempts) <- resultsByTaskId.to(Seq)
       attempt <- attempts
     } yield (tid, attempt)
     

--- a/src/test/scala/loamstream/drm/SessionTrackerTest.scala
+++ b/src/test/scala/loamstream/drm/SessionTrackerTest.scala
@@ -2,6 +2,8 @@ package loamstream.drm
 
 import org.scalatest.FunSuite
 
+import scala.collection.compat._
+
 /**
  * @author clint
  * Jan 12, 2021
@@ -26,19 +28,19 @@ final class SessionTrackerTest extends FunSuite {
     
     assert(tracker.isEmpty === false)
     assert(tracker.nonEmpty === true)
-    assert(tracker.taskArrayIdsSoFar.toSet === Set("foo"))
+    assert(tracker.taskArrayIdsSoFar.to(Set) === Set("foo"))
     
     tracker.register(Nil)
     
     assert(tracker.isEmpty === false)
     assert(tracker.nonEmpty === true)
-    assert(tracker.taskArrayIdsSoFar.toSet === Set("foo"))
+    assert(tracker.taskArrayIdsSoFar.to(Set) === Set("foo"))
     
     tracker.register(Seq(tid3, tid4, tid2))
     
     assert(tracker.isEmpty === false)
     assert(tracker.nonEmpty === true)
-    assert(tracker.taskArrayIdsSoFar.toSet === Set("foo", "bar", "baz", "blerg"))
+    assert(tracker.taskArrayIdsSoFar.to(Set) === Set("foo", "bar", "baz", "blerg"))
   }
   
   test("Noop") {

--- a/src/test/scala/loamstream/drm/lsf/BacctAccountingClientTest.scala
+++ b/src/test/scala/loamstream/drm/lsf/BacctAccountingClientTest.scala
@@ -16,8 +16,8 @@ import loamstream.model.quantities.CpuTime
 import loamstream.model.quantities.Memory
 import loamstream.util.CommandInvoker
 import loamstream.util.RunResults
-import rx.lang.scala.schedulers.ComputationScheduler
 import loamstream.util.LogContext
+import monix.execution.Scheduler
 
 /**
  * @author clint
@@ -47,7 +47,7 @@ final class BacctAccountingClientTest extends FunSuite {
           0, 
           "MOCK", 
           _ => runResultsAttempt(stdout = bacctOutput), 
-          scheduler = ComputationScheduler())
+          scheduler = Scheduler.computation())
 
       val taskId = DrmTaskId("foo", 42)
       
@@ -67,7 +67,7 @@ final class BacctAccountingClientTest extends FunSuite {
         0, 
         "MOCK", 
         _ => runResultsAttempt(stdout = splitOutput),
-        scheduler = ComputationScheduler())
+        scheduler = Scheduler.computation())
     
     val taskId = DrmTaskId("someJobId", 42)
     
@@ -104,7 +104,7 @@ final class BacctAccountingClientTest extends FunSuite {
           0, 
           "MOCK", 
           _ => runResultsAttempt(stdout = splitOutput),
-          scheduler = ComputationScheduler())
+          scheduler = Scheduler.computation())
       
       val taskId = DrmTaskId("someJobId", 42)
       
@@ -139,7 +139,7 @@ final class BacctAccountingClientTest extends FunSuite {
         0, 
         "MOCK", 
         _ => runResultsAttempt(stdout = splitOutput),
-        scheduler = ComputationScheduler())
+        scheduler = Scheduler.computation())
     
     val taskId = DrmTaskId("someJobId", 42)
     

--- a/src/test/scala/loamstream/drm/lsf/BsubJobSubmitterTest.scala
+++ b/src/test/scala/loamstream/drm/lsf/BsubJobSubmitterTest.scala
@@ -22,6 +22,7 @@ import loamstream.model.quantities.Memory
 import loamstream.util.RunResults
 import loamstream.drm.DrmTaskId
 import loamstream.util.Observables
+import monix.execution.Scheduler
 
 /**
  * @author clint
@@ -31,6 +32,7 @@ final class BsubJobSubmitterTest extends FunSuite {
   import loamstream.TestHelpers.path
   import loamstream.TestHelpers.waitFor
   import Observables.Implicits.ObservableOps
+  import Scheduler.Implicits.global
   
   test("submitJobs - happy path") {
     def submissionFn(drmSettings: DrmSettings, taskArray: DrmTaskArray): Try[RunResults] = {

--- a/src/test/scala/loamstream/drm/uger/MockQacctAccountingClient.scala
+++ b/src/test/scala/loamstream/drm/uger/MockQacctAccountingClient.scala
@@ -12,8 +12,9 @@ import loamstream.model.jobs.TerminationReason
 import loamstream.util.CommandInvoker
 import loamstream.util.RunResults
 import loamstream.util.ValueBox
-import rx.lang.scala.schedulers.ComputationScheduler
 import loamstream.util.LogContext
+import scala.concurrent.duration.FiniteDuration
+import monix.execution.Scheduler
 
 /**
  * @author clint
@@ -22,8 +23,8 @@ import loamstream.util.LogContext
 final class MockQacctAccountingClient(
     delegateFn: DrmTaskId => Try[RunResults],
     ugerConfig: UgerConfig = UgerConfig(),
-    delayStart: Duration = CommandInvoker.Async.Retrying.defaultDelayStart,
-    delayCap: Duration = CommandInvoker.Async.Retrying.defaultDelayCap) extends AccountingClient {
+    delayStart: FiniteDuration = CommandInvoker.Async.Retrying.defaultDelayStart,
+    delayCap: FiniteDuration = CommandInvoker.Async.Retrying.defaultDelayCap) extends AccountingClient {
   
   private val timesGetQacctOutputForInvokedBox: ValueBox[Int] = ValueBox(0)
 
@@ -57,7 +58,7 @@ final class MockQacctAccountingClient(
           wrappedDelegateFn, 
           delayStart, 
           delayCap,
-          scheduler = ComputationScheduler())
+          scheduler = Scheduler.computation())
     }
     
     new QacctAccountingClient(invoker)

--- a/src/test/scala/loamstream/drm/uger/QdelJobKillerTest.scala
+++ b/src/test/scala/loamstream/drm/uger/QdelJobKillerTest.scala
@@ -3,6 +3,7 @@ package loamstream.drm.uger
 import org.scalatest.FunSuite
 import loamstream.drm.SessionTracker
 import loamstream.drm.DrmTaskId
+import scala.collection.compat._
 
 /**
  * @author clint
@@ -28,7 +29,7 @@ final class QdelJobKillerTest extends FunSuite {
     assert(sessionTracker.nonEmpty)
     assert(tokens.startsWith(Seq("foo", "-u", "bar")))
     assert(tokens.size === 4)
-    assert(tokens(3).split(",").toSet === Set("blarg", "blah"))
+    assert(tokens(3).split(",").to(Set) === Set("blarg", "blah"))
     
     sessionTracker.register(Seq(DrmTaskId("zuh", 2)))
     
@@ -36,6 +37,6 @@ final class QdelJobKillerTest extends FunSuite {
     assert(sessionTracker.nonEmpty)
     assert(tokens.startsWith(Seq("foo", "-u", "bar")))
     assert(tokens.size === 4)
-    assert(tokens(3).split(",").toSet === Set("blarg", "blah", "zuh"))
+    assert(tokens(3).split(",").to(Set) === Set("blarg", "blah", "zuh"))
   }
 }

--- a/src/test/scala/loamstream/drm/uger/QstatPollerTest.scala
+++ b/src/test/scala/loamstream/drm/uger/QstatPollerTest.scala
@@ -17,6 +17,7 @@ import loamstream.util.LogContext
 import monix.execution.Scheduler
 import loamstream.TestHelpers.DummyDrmJobOracle
 import loamstream.util.Files
+import scala.collection.compat._
 
 /**
  * @author clint
@@ -162,7 +163,7 @@ final class QstatPollerTest extends FunSuite {
         case Failure(_) => ???
       }
       
-      s.toSeq.sorted(ordering)
+      s.to(Seq).sorted(ordering)
     }
         
     assert(sort(QstatSupport.parseQstatOutput(ids, lines).toList) === sort(expected))

--- a/src/test/scala/loamstream/drm/uger/QstatPollerTest.scala
+++ b/src/test/scala/loamstream/drm/uger/QstatPollerTest.scala
@@ -90,7 +90,9 @@ final class QstatPollerTest extends FunSuite {
     }
     
     {
-      val results = poller.poll(DummyDrmJobOracle)(runningTaskIds :+ finishedTaskId).toListL.runSyncUnsafe(TestHelpers.defaultWaitTime)
+      val results = poller.poll(DummyDrmJobOracle)(runningTaskIds :+ finishedTaskId)
+                          .toListL
+                          .runSyncUnsafe(TestHelpers.defaultWaitTime)
       
       val expected = Seq(
           runningTaskIds(0) -> Success(DrmStatus.Running),

--- a/src/test/scala/loamstream/drm/uger/QstatPollerTest.scala
+++ b/src/test/scala/loamstream/drm/uger/QstatPollerTest.scala
@@ -115,9 +115,9 @@ final class QstatPollerTest extends FunSuite {
       Success(id2 -> DrmStatus.Running),
       Success(id1 -> DrmStatus.Running))
         
-    assert(QstatSupport.parseQstatOutput(ids, qstatLines).toList === expected)
+    assert(QstatSupport.parseQstatOutput(ids, qstatLines).to(List) === expected)
     
-    assert(QstatSupport.parseQstatOutput(ids, dataLines).toList === expected)
+    assert(QstatSupport.parseQstatOutput(ids, dataLines).to(List) === expected)
     
     assert(QstatSupport.parseQstatOutput(ids, headerLines).isEmpty)
     
@@ -166,7 +166,7 @@ final class QstatPollerTest extends FunSuite {
       s.to(Seq).sorted(ordering)
     }
         
-    assert(sort(QstatSupport.parseQstatOutput(ids, lines).toList) === sort(expected))
+    assert(sort(QstatSupport.parseQstatOutput(ids, lines).to(List)) === sort(expected))
   }
   
   test("parseQstatOutput - bad lines should be ignored") {
@@ -184,7 +184,7 @@ final class QstatPollerTest extends FunSuite {
       Success(id2 -> DrmStatus.Running),
       Success(id1 -> DrmStatus.Running))
         
-    assert(QstatSupport.parseQstatOutput(ids, lines).toList === expected)
+    assert(QstatSupport.parseQstatOutput(ids, lines).to(List) === expected)
   }
   
   test("parseQstatOutput - bad statuses should be failures") {
@@ -196,7 +196,7 @@ final class QstatPollerTest extends FunSuite {
     
     val ids = Set(id1, id2, id3)
     
-    val actual = QstatSupport.parseQstatOutput(ids, lines).toList
+    val actual = QstatSupport.parseQstatOutput(ids, lines).to(List)
     
     assert(actual.forall { 
       case Success((drmTaskId, drmStatus)) => drmStatus.isUndetermined

--- a/src/test/scala/loamstream/drm/uger/RateLimitedQacctInvokerTest.scala
+++ b/src/test/scala/loamstream/drm/uger/RateLimitedQacctInvokerTest.scala
@@ -6,9 +6,9 @@ import loamstream.util.RunResults
 import scala.util.Success
 import scala.util.Failure
 import scala.concurrent.duration._
-import rx.lang.scala.schedulers.IOScheduler
 import loamstream.TestHelpers.waitFor
 import loamstream.util.Sequence
+import monix.execution.Scheduler
 
 /**
  * @author clint
@@ -49,7 +49,7 @@ final class RateLimitedQacctInvokerTest extends FunSuite {
         maxSize = 3, 
         maxAge = 1.second, 
         maxRetries = 0,
-        scheduler = IOScheduler())
+        scheduler = Scheduler.io())
     
     val invoker = caches.commandInvoker
     

--- a/src/test/scala/loamstream/googlecloud/GoogleCloudChunkRunnerTest.scala
+++ b/src/test/scala/loamstream/googlecloud/GoogleCloudChunkRunnerTest.scala
@@ -1,31 +1,28 @@
 package loamstream.googlecloud
 
+import java.nio.file.Path
+
 import scala.concurrent.ExecutionContext
 
 import org.scalatest.FunSuite
 
 import loamstream.TestHelpers
+import loamstream.conf.ExecutionConfig
 import loamstream.model.execute.AsyncLocalChunkRunner
-import loamstream.model.execute.EnvironmentType
+import loamstream.model.execute.GoogleSettings
 import loamstream.model.execute.MockChunkRunner
 import loamstream.model.execute.ProvidesEnvAndResources
 import loamstream.model.execute.Resources
 import loamstream.model.execute.Resources.GoogleResources
-import loamstream.model.jobs.Execution
+import loamstream.model.execute.Resources.LocalResources
 import loamstream.model.jobs.JobResult
 import loamstream.model.jobs.JobResult.CommandResult
 import loamstream.model.jobs.LJob
 import loamstream.model.jobs.MockJob
-import loamstream.util.ValueBox
-import loamstream.conf.ExecutionConfig
-import loamstream.model.jobs.OutputStreams
 import loamstream.model.jobs.RunData
-import loamstream.util.Maps
-import java.nio.file.Path
-import loamstream.model.execute.GoogleSettings
-import loamstream.model.execute.Resources.LocalResources
-import loamstream.model.execute.Settings
-import monix.execution.Scheduler
+import loamstream.util.ValueBox
+
+import scala.collection.compat._
 
 
 /**
@@ -36,9 +33,9 @@ final class GoogleCloudChunkRunnerTest extends FunSuite with ProvidesEnvAndResou
   
   import GoogleCloudChunkRunnerTest.LiteralMockDataProcClient
   import GoogleCloudChunkRunnerTest.MockDataProcClient
-  import loamstream.util.Observables.Implicits._
   import loamstream.TestHelpers.waitFor
-  import Scheduler.Implicits.global
+  import loamstream.util.Observables.Implicits._
+  import monix.execution.Scheduler.Implicits.global
 
   private val clusterId = "some-cluster-id"
   
@@ -397,7 +394,7 @@ final class GoogleCloudChunkRunnerTest extends FunSuite with ProvidesEnvAndResou
       val jobRuns = waitFor(runDataObs.foldLeft(z)(_ + _).firstAsFuture)
       
       assert(client.clusterRunning() === true)
-      assert(client.startClusterInvocations().toSet === 
+      assert(client.startClusterInvocations().to(Set) === 
         Set(settings12.clusterConfig, settings3.clusterConfig, settings4.clusterConfig))
       assert(client.deleteClusterInvocations() === 2)
       

--- a/src/test/scala/loamstream/googlecloud/GoogleCloudChunkRunnerTest.scala
+++ b/src/test/scala/loamstream/googlecloud/GoogleCloudChunkRunnerTest.scala
@@ -25,6 +25,7 @@ import java.nio.file.Path
 import loamstream.model.execute.GoogleSettings
 import loamstream.model.execute.Resources.LocalResources
 import loamstream.model.execute.Settings
+import monix.execution.Scheduler
 
 
 /**
@@ -37,6 +38,7 @@ final class GoogleCloudChunkRunnerTest extends FunSuite with ProvidesEnvAndResou
   import GoogleCloudChunkRunnerTest.MockDataProcClient
   import loamstream.util.Observables.Implicits._
   import loamstream.TestHelpers.waitFor
+  import Scheduler.Implicits.global
 
   private val clusterId = "some-cluster-id"
   
@@ -307,7 +309,9 @@ final class GoogleCloudChunkRunnerTest extends FunSuite with ProvidesEnvAndResou
       assert(client.startClusterInvocations() === Nil)
       assert(client.deleteClusterInvocations() === 0)
       
-      val result = waitFor(googleRunner.run(Set.empty, TestHelpers.DummyJobOracle).to[Seq].firstAsFuture)
+      val result = {
+        googleRunner.run(Set.empty, TestHelpers.DummyJobOracle).toListL.runSyncUnsafe(TestHelpers.defaultWaitTime)
+      }
       
       assert(client.clusterRunning() === false)
       assert(client.startClusterInvocations() === Nil)

--- a/src/test/scala/loamstream/googlecloud/GoogleCloudChunkRunnerTest.scala
+++ b/src/test/scala/loamstream/googlecloud/GoogleCloudChunkRunnerTest.scala
@@ -392,8 +392,6 @@ final class GoogleCloudChunkRunnerTest extends FunSuite with ProvidesEnvAndResou
       
       val z: Map[LJob, RunData] = Map.empty
       
-      println(s"%%%%%%%%%%%%% running: ${Seq(job1, job2, job3, job4).map(_.id)}")
-      
       val runDataObs = googleRunner.run(Seq(job1, job2, job3, job4), TestHelpers.DummyJobOracle)
       
       val jobRuns = waitFor(runDataObs.foldLeft(z)(_ + _).firstAsFuture)
@@ -781,8 +779,6 @@ object GoogleCloudChunkRunnerTest {
     
     override def stopCluster(): Unit = {
       deleteClusterInvocations.mutate(_ + 1)
-      
-      println(s"Deleting cluster from ${Thread.currentThread.getName}")
       
       clusterRunning := false
     }

--- a/src/test/scala/loamstream/googlecloud/GoogleCloudChunkRunnerTest.scala
+++ b/src/test/scala/loamstream/googlecloud/GoogleCloudChunkRunnerTest.scala
@@ -163,7 +163,7 @@ final class GoogleCloudChunkRunnerTest extends FunSuite with ProvidesEnvAndResou
       
       val z: Map[LJob, RunData] = Map.empty 
       
-      val runDatas = waitFor(runDataObs.foldLeft(z)(_ + _).lastAsFuture)
+      val runDatas = waitFor(runDataObs.foldLeft(z)(_ + _).firstAsFuture)
       
       assert(runDatas(job1) === job1.toReturn)
       assert(runDatas(job2) === job2.toReturn)
@@ -337,7 +337,7 @@ final class GoogleCloudChunkRunnerTest extends FunSuite with ProvidesEnvAndResou
       
       val runDataObs = googleRunner.run(Set(job1, job2, job3), TestHelpers.DummyJobOracle)
       
-      val jobRuns = waitFor(runDataObs.foldLeft(z)(_ + _).lastAsFuture)
+      val jobRuns = waitFor(runDataObs.foldLeft(z)(_ + _).firstAsFuture)
       
       assert(client.clusterRunning() === true)
       assert(client.startClusterInvocations() === Seq(clusterConfigFrom(job1)))
@@ -392,9 +392,11 @@ final class GoogleCloudChunkRunnerTest extends FunSuite with ProvidesEnvAndResou
       
       val z: Map[LJob, RunData] = Map.empty
       
-      val runDataObs = googleRunner.run(Set(job1, job2, job3, job4), TestHelpers.DummyJobOracle)
+      println(s"%%%%%%%%%%%%% running: ${Seq(job1, job2, job3, job4).map(_.id)}")
       
-      val jobRuns = waitFor(runDataObs.foldLeft(z)(_ + _).lastAsFuture)
+      val runDataObs = googleRunner.run(Seq(job1, job2, job3, job4), TestHelpers.DummyJobOracle)
+      
+      val jobRuns = waitFor(runDataObs.foldLeft(z)(_ + _).firstAsFuture)
       
       assert(client.clusterRunning() === true)
       assert(client.startClusterInvocations().toSet === 
@@ -454,7 +456,7 @@ final class GoogleCloudChunkRunnerTest extends FunSuite with ProvidesEnvAndResou
       assert(client.delegate.deleteClusterInvocations() === 0)
       
       val thrown = intercept[Exception] {
-        waitFor(googleRunner.run(Set(job1, job2, job3), TestHelpers.DummyJobOracle).lastAsFuture)
+        waitFor(googleRunner.run(Set(job1, job2, job3), TestHelpers.DummyJobOracle).firstAsFuture)
       }
       
       assert(thrown === e)
@@ -480,7 +482,7 @@ final class GoogleCloudChunkRunnerTest extends FunSuite with ProvidesEnvAndResou
       
       val job1 = mockJob(JobResult.Success)
       
-      waitFor(googleRunner.run(Set(job1), TestHelpers.DummyJobOracle).lastAsFuture)
+      waitFor(googleRunner.run(Set(job1), TestHelpers.DummyJobOracle).firstAsFuture)
       
       assert(client.isClusterRunningInvocations() === 2)
       
@@ -517,7 +519,7 @@ final class GoogleCloudChunkRunnerTest extends FunSuite with ProvidesEnvAndResou
       
       val job1 = mockJob(JobResult.Success)
       
-      waitFor(googleRunner.run(Set(job1), TestHelpers.DummyJobOracle).lastAsFuture)
+      waitFor(googleRunner.run(Set(job1), TestHelpers.DummyJobOracle).firstAsFuture)
       
       assert(client.delegate.isClusterRunningInvocations() === 2)
       
@@ -560,7 +562,7 @@ final class GoogleCloudChunkRunnerTest extends FunSuite with ProvidesEnvAndResou
       
       val job1 = mockJob(JobResult.Success)
       
-      waitFor(googleRunner.run(Set(job1), TestHelpers.DummyJobOracle).lastAsFuture)
+      waitFor(googleRunner.run(Set(job1), TestHelpers.DummyJobOracle).firstAsFuture)
       
       assert(client.delegate.isClusterRunningInvocations() === 2)
       
@@ -592,7 +594,7 @@ final class GoogleCloudChunkRunnerTest extends FunSuite with ProvidesEnvAndResou
       
       val job1 = mockJob(JobResult.Success)
       
-      waitFor(googleRunner.run(Set(job1), TestHelpers.DummyJobOracle).lastAsFuture)
+      waitFor(googleRunner.run(Set(job1), TestHelpers.DummyJobOracle).firstAsFuture)
       
       assert(client.clusterRunning() === true)
       
@@ -641,7 +643,7 @@ final class GoogleCloudChunkRunnerTest extends FunSuite with ProvidesEnvAndResou
       
       val job1 = mockJob(JobResult.Success)
       
-      waitFor(googleRunner.run(Set(job1), TestHelpers.DummyJobOracle).lastAsFuture)
+      waitFor(googleRunner.run(Set(job1), TestHelpers.DummyJobOracle).firstAsFuture)
       
       assert(client.delegate.clusterRunning() === true)
       assert(client.delegate.startClusterInvocations() === Seq(clusterConfig0, clusterConfig0))
@@ -701,7 +703,7 @@ final class GoogleCloudChunkRunnerTest extends FunSuite with ProvidesEnvAndResou
       
       val job1 = mockJob(JobResult.Success)
       
-      waitFor(googleRunner.run(Set(job1), TestHelpers.DummyJobOracle).lastAsFuture)
+      waitFor(googleRunner.run(Set(job1), TestHelpers.DummyJobOracle).firstAsFuture)
       
       assert(client.delegate.clusterRunning() === true)
       assert(client.delegate.startClusterInvocations() === Seq(clusterConfig1))
@@ -779,6 +781,8 @@ object GoogleCloudChunkRunnerTest {
     
     override def stopCluster(): Unit = {
       deleteClusterInvocations.mutate(_ + 1)
+      
+      println(s"Deleting cluster from ${Thread.currentThread.getName}")
       
       clusterRunning := false
     }

--- a/src/test/scala/loamstream/loam/LoamToolBoxTest.scala
+++ b/src/test/scala/loamstream/loam/LoamToolBoxTest.scala
@@ -18,7 +18,7 @@ import loamstream.util.DirOracle
 import loamstream.util.jvm.JvmArgs
 import loamstream.util.jvm.SysPropNames
 import loamstream.model.jobs.DataHandle
-
+import scala.collection.compat._
 
 
 /**
@@ -366,7 +366,7 @@ final class LoamToolBoxTest extends FunSuite {
   }
     
   test("makeWorkerJobCommandLineTokens - happy path") {
-    val args = "--backend uger --loams foo.loam".split("\\s+").toList
+    val args = "--backend uger --loams foo.loam".split("\\s+").to(List)
     
     val jobName = "some-job"
     

--- a/src/test/scala/loamstream/loam/intake/AggregatorRowExprTest.scala
+++ b/src/test/scala/loamstream/loam/intake/AggregatorRowExprTest.scala
@@ -3,6 +3,7 @@ package loamstream.loam.intake
 import org.scalatest.FunSuite
 import scala.reflect.runtime.universe.TypeTag
 import loamstream.loam.intake.flip.Disposition
+import scala.collection.compat._
 
 /**
  * @author clint
@@ -113,10 +114,10 @@ final class AggregatorRowExprTest extends FunSuite {
       //Should fail, since we've declared a value for betaDef, but there is no beta column in the input
       if(failFast) {
         intercept[Exception] {
-          dataRows.records.toList
+          dataRows.records.to(List)
         }
       } else {
-        val results = dataRows.records.toList
+        val results = dataRows.records.to(List)
         
         assert(results.map(_.isSkipped) === Seq(true, true, true))
       }
@@ -158,7 +159,7 @@ final class AggregatorRowExprTest extends FunSuite {
                             map(_.skip).
                             map(expr).
                             records.
-                            toList
+                            to(List)
                             
     assert(skippedDataRows.map(_.isSkipped) === Seq(true, true, true))
   }

--- a/src/test/scala/loamstream/loam/intake/AwsRowSinkTest.scala
+++ b/src/test/scala/loamstream/loam/intake/AwsRowSinkTest.scala
@@ -8,6 +8,7 @@ import AwsRowSinkTest.MockAwsClient
 import java.util.UUID
 import org.json4s.JsonAST.JValue
 import loamstream.loam.intake.dga.Json
+import scala.collection.compat._
 
 /**
  * @author clint
@@ -210,7 +211,7 @@ object AwsRowSinkTest {
     
     override def list(prefix: String, delimiter: String): Seq[String] = {
       //TODO: Delim?
-      data.keys.toSeq.sorted.filter(_.startsWith(prefix))
+      data.keys.to(Seq).sorted.filter(_.startsWith(prefix))
     }
   
     override def deleteDir(key: String): Unit = {

--- a/src/test/scala/loamstream/loam/intake/CsvRowTest.scala
+++ b/src/test/scala/loamstream/loam/intake/CsvRowTest.scala
@@ -2,6 +2,7 @@ package loamstream.loam.intake
 
 import org.scalatest.FunSuite
 import loamstream.loam.intake.flip.Disposition
+import scala.collection.compat._
 
 /**
  * @author clint
@@ -15,7 +16,7 @@ object CsvRowTest {
       
       val rows = Source.fromString(csvData, Source.Formats.spaceDelimitedWithHeader)
           
-      val rowsList = rows.records.toList
+      val rowsList = rows.records.to(List)
       
       assert(rowsList.size === 1)
       
@@ -41,7 +42,7 @@ final class CsvRowTest extends FunSuite with CsvRowTest.RowHelpers {
     assert(firstRow.getFieldByIndex(1) === "hello")
     assert(firstRow.getFieldByIndex(2) === "blah_123")
     
-    assert(firstRow.values.toList === (Seq("1", "hello", "blah_123").map(Option(_))))
+    assert(firstRow.values.to(List) === (Seq("1", "hello", "blah_123").map(Option(_))))
     
     val skipped = firstRow.skip
     
@@ -53,9 +54,9 @@ final class CsvRowTest extends FunSuite with CsvRowTest.RowHelpers {
     assert(skipped.isSkipped === true)
     assert(skipped.notSkipped === false)
     
-    assert(firstRow.values.toList === Seq("1", "hello", "blah_123").map(Option(_)))
+    assert(firstRow.values.to(List) === Seq("1", "hello", "blah_123").map(Option(_)))
     
-    assert(firstRow.values.toList === skipped.values.toList)
+    assert(firstRow.values.to(List) === skipped.values.to(List))
   }
   
 }

--- a/src/test/scala/loamstream/loam/intake/Helpers.scala
+++ b/src/test/scala/loamstream/loam/intake/Helpers.scala
@@ -8,6 +8,8 @@ import loamstream.model.Store
 import loamstream.loam.intake.flip.FlipDetector
 import loamstream.loam.intake.flip.Disposition
 import loamstream.loam.intake.metrics.BioIndexClient
+import scala.collection.compat._
+
 
 /**
  * @author clint
@@ -73,7 +75,7 @@ object Helpers {
   def linesFrom(path: Path): Seq[String] = {
     import scala.collection.JavaConverters._
     
-    java.nio.file.Files.readAllLines(path).asScala.toSeq
+    java.nio.file.Files.readAllLines(path).asScala.to(Seq)
   }
   
   object Implicits {

--- a/src/test/scala/loamstream/loam/intake/IntakeSyntaxTest.scala
+++ b/src/test/scala/loamstream/loam/intake/IntakeSyntaxTest.scala
@@ -11,6 +11,8 @@ import loamstream.util.Files
 import loamstream.loam.InvokesLsTool
 import loamstream.drm.DrmSystem
 
+import scala.collection.compat._
+
 /**
  * @author clint
  * Nov 19, 2020
@@ -70,7 +72,7 @@ final class IntakeSyntaxTest extends FunSuite {
           ("c3", true),
           ("d4", false))
           
-      assert(filtered.rows.records.toList.map(toTuple) === expected)
+      assert(filtered.rows.records.to(List).map(toTuple) === expected)
     }
   }
   
@@ -94,7 +96,7 @@ final class IntakeSyntaxTest extends FunSuite {
           ("c3", false),
           ("d4", false))
           
-      assert(filtered.rows.records.toList.map(toTuple) === expected)
+      assert(filtered.rows.records.to(List).map(toTuple) === expected)
     }
   }
   
@@ -120,7 +122,7 @@ final class IntakeSyntaxTest extends FunSuite {
           ("c3", false),
           ("d4", true))
           
-      assert(filtered.rows.records.toList.map(toTuple) === expected)
+      assert(filtered.rows.records.to(List).map(toTuple) === expected)
     }
   }
   
@@ -189,7 +191,7 @@ final class IntakeSyntaxTest extends FunSuite {
       
       assert(target.toBeClosed === Nil)
       
-      val unfilteredRows = source.records.toList
+      val unfilteredRows = source.records.to(List)
       
       val p = MockCloseablePredicate[PValueVariantRow](_.pvalue > 0.2)
       
@@ -199,7 +201,7 @@ final class IntakeSyntaxTest extends FunSuite {
       
       val expected = unfilteredRows.take(2).map(_.skip) ++ unfilteredRows.drop(2)
       
-      assert(filtered.rows.records.toList === expected)
+      assert(filtered.rows.records.to(List) === expected)
     }
   }
   
@@ -211,7 +213,7 @@ final class IntakeSyntaxTest extends FunSuite {
       val source = {
         val orig = mapSource.tagFlips(markerDef, Helpers.FlipDetectors.NoFlipsEver).map(expr)
         
-        val unfilteredRows = orig.records.toList
+        val unfilteredRows = orig.records.to(List)
         
         Source.fromIterable(unfilteredRows.take(2).map(_.skip) ++ unfilteredRows.drop(2))
       }
@@ -225,13 +227,13 @@ final class IntakeSyntaxTest extends FunSuite {
       
       assert(target.toBeClosed === Nil)
       
-      val unfilteredRows = source.records.toList
+      val unfilteredRows = source.records.to(List)
       
       val filtered = target.filter(_.pvalue > 0.3)
       
       val expected = unfilteredRows.take(3).map(_.skip) ++ unfilteredRows.drop(3)
       
-      assert(filtered.rows.records.toList === expected)
+      assert(filtered.rows.records.to(List) === expected)
     }
   }
   
@@ -243,7 +245,7 @@ final class IntakeSyntaxTest extends FunSuite {
       val source = {
         val orig = mapSource.tagFlips(markerDef, Helpers.FlipDetectors.NoFlipsEver).map(expr)
         
-        val unfilteredRows = orig.records.toList
+        val unfilteredRows = orig.records.to(List)
         
         Source.fromIterable(unfilteredRows.take(2).map(_.skip) ++ unfilteredRows.drop(2))
       }
@@ -257,7 +259,7 @@ final class IntakeSyntaxTest extends FunSuite {
       
       assert(target.toBeClosed === Nil)
       
-      val unmappedRows = source.records.toList
+      val unmappedRows = source.records.to(List)
       
       val f: Transform[PValueVariantRow] = MockCloseableTransform { dr => 
         dr.copy(pvalue = dr.pvalue + 1.0)
@@ -269,7 +271,7 @@ final class IntakeSyntaxTest extends FunSuite {
       
       val expected = unmappedRows.take(2) ++ unmappedRows.drop(2).map(_.transform(f))
       
-      assert(mapped.rows.records.toList === expected)
+      assert(mapped.rows.records.to(List) === expected)
     }
   }
   
@@ -285,7 +287,7 @@ final class IntakeSyntaxTest extends FunSuite {
         val source = {
           val orig = mapSource.tagFlips(markerDef, Helpers.FlipDetectors.NoFlipsEver).map(expr)
           
-          val unfilteredRows = orig.records.toList
+          val unfilteredRows = orig.records.to(List)
           
           Source.fromIterable(unfilteredRows.take(2).map(_.skip) ++ unfilteredRows.drop(2))
         }
@@ -299,7 +301,7 @@ final class IntakeSyntaxTest extends FunSuite {
         
         assert(target.toBeClosed === Nil)
         
-        val unmappedRows = source.records.toList
+        val unmappedRows = source.records.to(List)
         
         val f = MockCloseableTransform[PValueVariantRow] { dr => 
           dr.copy(pvalue = dr.pvalue + 1.0)

--- a/src/test/scala/loamstream/loam/intake/ProcessRealDataTest.scala
+++ b/src/test/scala/loamstream/loam/intake/ProcessRealDataTest.scala
@@ -11,6 +11,8 @@ import loamstream.util.Loggable
 import loamstream.compiler.LoamEngine
 import loamstream.model.execute.RxExecuter
 
+import scala.collection.compat._
+
 /**
  * @author clint
  * Apr 6, 2020
@@ -149,8 +151,8 @@ final class ProcessRealDataTest extends FunSuite with Loggable {
           asDouble(MAF_PH.name))
       }
         
-      val actualRecords = actual.records.toList
-      val expectedRecords = expected.records.toList
+      val actualRecords = actual.records.to(List)
+      val expectedRecords = expected.records.to(List)
       
       actualRecords.zip(expectedRecords).foreach { case (lhs, rhs) => assertSame(lhs, rhs, expectations) }
       

--- a/src/test/scala/loamstream/loam/intake/SourceTest.scala
+++ b/src/test/scala/loamstream/loam/intake/SourceTest.scala
@@ -9,6 +9,8 @@ import loamstream.loam.intake.metrics.MetricTest.MockFlipDetector
 import loamstream.loam.intake.flip.FlipDetector
 import loamstream.loam.intake.flip.Disposition
 
+import scala.collection.compat._
+
 /**
  * @author clint
  * Feb 27, 2020
@@ -50,7 +52,7 @@ final class SourceTest extends FunSuite {
     
     val expected = Seq(2, 4, 4, 6, 6, 6)
     
-    assert(is.records.toList === expected)
+    assert(is.records.to(List) === expected)
   }
   
   test("Reading zipped input as unzipped should fail") {

--- a/src/test/scala/loamstream/loam/intake/VariantRowTest.scala
+++ b/src/test/scala/loamstream/loam/intake/VariantRowTest.scala
@@ -2,6 +2,7 @@ package loamstream.loam.intake
 
 import org.scalatest.FunSuite
 import loamstream.loam.intake.flip.Disposition
+import scala.collection.compat._
 
 /**
  * @author clint
@@ -28,7 +29,7 @@ final class VariantRowTest extends FunSuite with CsvRowTest.RowHelpers {
       
       assert(tagged.size === delegate.size)
       
-      assert(tagged.values.toList === delegate.values.toList)
+      assert(tagged.values.to(List) === delegate.values.to(List))
       
       assert(tagged.recordNumber === delegate.recordNumber)
       
@@ -43,7 +44,7 @@ final class VariantRowTest extends FunSuite with CsvRowTest.RowHelpers {
       assert(skipped.isSkipped === true)
       assert(skipped.notSkipped === false)
       
-      assert(skipped.values.toList === tagged.values.toList)
+      assert(skipped.values.to(List) === tagged.values.to(List))
     }
     
     doTest(Disposition.FlippedComplementStrand)

--- a/src/test/scala/loamstream/loam/intake/dga/BedRowExprTest.scala
+++ b/src/test/scala/loamstream/loam/intake/dga/BedRowExprTest.scala
@@ -4,6 +4,7 @@ import org.scalatest.FunSuite
 import loamstream.loam.intake.ColumnExpr
 import loamstream.loam.intake.DataRow
 import loamstream.loam.intake.Helpers
+import scala.collection.compat._
 
 /**
  * @author clint
@@ -148,7 +149,7 @@ final class BedRowExprTest extends FunSuite {
       columnNames: String*): Unit = {
     
     val rows = for {
-      v <- naValues.toSeq
+      v <- naValues.to(Seq)
       columnName <- columnNames
     } yield Helpers.csvRow("foo" -> "bar", columnName -> v)
 

--- a/src/test/scala/loamstream/loam/intake/metrics/MetricTest.scala
+++ b/src/test/scala/loamstream/loam/intake/metrics/MetricTest.scala
@@ -18,6 +18,7 @@ import loamstream.loam.intake.RowSink
 import loamstream.loam.intake.RenderableRow
 import loamstream.loam.intake.BaseVariantRow
 import loamstream.loam.intake.LiteralColumnExpr
+import scala.collection.compat._
 
 
 /**
@@ -586,7 +587,7 @@ final class MetricTest extends FunSuite {
     
     assert(Fold.fold(rows.records)(metric) === expected)
     
-    assert(Fold.fold(rows.records.toList)(metric) === expected)
+    assert(Fold.fold(rows.records.to(List))(metric) === expected)
   }
 }
 

--- a/src/test/scala/loamstream/model/LIdTest.scala
+++ b/src/test/scala/loamstream/model/LIdTest.scala
@@ -2,6 +2,8 @@ package loamstream.model
 
 import org.scalatest.FunSuite
 
+import scala.collection.compat._
+
 /**
  * @author clint
  * date: May 23, 2016
@@ -71,6 +73,6 @@ final class LIdTest extends FunSuite {
     val ids = (0 until n).map(_ => newAnonId)
     
     assert(ids.size == n)
-    assert(ids.toSet.size == n)
+    assert(ids.to(Set).size == n)
   }
 }

--- a/src/test/scala/loamstream/model/execute/CompositeChunkRunnerTest.scala
+++ b/src/test/scala/loamstream/model/execute/CompositeChunkRunnerTest.scala
@@ -14,6 +14,7 @@ import loamstream.TestHelpers
 import loamstream.model.jobs.JobOracle
 import monix.execution.Scheduler
 import monix.reactive.Observable
+import scala.collection.compat._
 
 /**
  * @author clint

--- a/src/test/scala/loamstream/model/execute/CompositeChunkRunnerTest.scala
+++ b/src/test/scala/loamstream/model/execute/CompositeChunkRunnerTest.scala
@@ -81,7 +81,7 @@ object CompositeChunkRunnerTest {
     private val delegate = local(1)
     
     override def run(
-        jobs: Set[LJob], 
+        jobs: Iterable[LJob], 
         jobOracle: JobOracle): Observable[(LJob, RunData)] = delegate.run(jobs, jobOracle)
   }
 }

--- a/src/test/scala/loamstream/model/execute/CompositeChunkRunnerTest.scala
+++ b/src/test/scala/loamstream/model/execute/CompositeChunkRunnerTest.scala
@@ -9,10 +9,11 @@ import loamstream.model.jobs.JobStatus
 import loamstream.model.jobs.LJob
 import loamstream.model.jobs.MockJob
 import loamstream.model.jobs.RunData
-import rx.lang.scala.Observable
 import loamstream.util.Observables
 import loamstream.TestHelpers
 import loamstream.model.jobs.JobOracle
+import monix.execution.Scheduler
+import monix.reactive.Observable
 
 /**
  * @author clint
@@ -59,13 +60,15 @@ final class CompositeChunkRunnerTest extends FunSuite {
       runner.run(Set(job1, job4), TestHelpers.DummyJobOracle)
     }
     
-    import Observables.Implicits._
-    
-    val futureResults = runner.run(Set(job1, job2), TestHelpers.DummyJobOracle).to[Seq].map(_.toMap).firstAsFuture
+    val results = {
+      import Scheduler.Implicits.global
+      
+      runner.run(Set(job1, job2), TestHelpers.DummyJobOracle).toListL.runSyncUnsafe(TestHelpers.defaultWaitTime).toMap
+    }
     
     val expected = Map(job1 -> JobStatus.Succeeded, job2 -> JobStatus.Failed)
     
-    assert(waitFor(futureResults).mapValues(_.jobStatus) === expected)
+    assert(results.mapValues(_.jobStatus) === expected)
   }
 }
 

--- a/src/test/scala/loamstream/model/execute/DbBackedExecutionRecorderTest.scala
+++ b/src/test/scala/loamstream/model/execute/DbBackedExecutionRecorderTest.scala
@@ -1,17 +1,20 @@
 package loamstream.model.execute
 
 import org.scalatest.FunSuite
-import loamstream.db.slick.ProvidesSlickLoamDao
-import loamstream.model.jobs.JobStatus
-import loamstream.model.jobs.JobResult
-import loamstream.model.jobs.Execution
-import loamstream.model.jobs.StoreRecord
-import loamstream.model.jobs.JobResult.CommandResult
+
+import loamstream.TestHelpers
 import loamstream.TestHelpers.dummyJobDir
 import loamstream.TestHelpers.path
+import loamstream.db.slick.ProvidesSlickLoamDao
 import loamstream.model.jobs.DataHandle
+import loamstream.model.jobs.Execution
+import loamstream.model.jobs.JobResult
+import loamstream.model.jobs.JobResult.CommandResult
+import loamstream.model.jobs.JobStatus
 import loamstream.model.jobs.MockJob
-import loamstream.TestHelpers
+import loamstream.model.jobs.StoreRecord
+
+import scala.collection.compat._
 
 /**
  * @author clint
@@ -216,7 +219,7 @@ final class DbBackedExecutionRecorderTest extends FunSuite with ProvidesSlickLoa
           else { baseStoreRecords.map(noHash) }
         }
         
-        val withHashedOutputs = e.withStoreRecords(storeRecords.toSet)
+        val withHashedOutputs = e.withStoreRecords(storeRecords.to(Set))
   
         recorder.record(TestHelpers.DummyJobOracle, Seq(job -> e))
   
@@ -254,7 +257,7 @@ final class DbBackedExecutionRecorderTest extends FunSuite with ProvidesSlickLoa
           else { baseStoreRecords.map(noHash) }
         }
         
-        val withHashedOutputs = e.withStoreRecords(storeRecords.toSet)
+        val withHashedOutputs = e.withStoreRecords(storeRecords.to(Set))
         
         val expected = withHashedOutputs.copy(result = Some(CommandResult(0)))
         
@@ -328,7 +331,7 @@ final class DbBackedExecutionRecorderTest extends FunSuite with ProvidesSlickLoa
           else { baseStoreRecords.map(noHash) }
         }
         
-        val expected = e.withStoreRecords(storeRecords.toSet)
+        val expected = e.withStoreRecords(storeRecords.to(Set))
   
         recorder.record(TestHelpers.DummyJobOracle, Seq(job -> e))
         

--- a/src/test/scala/loamstream/model/execute/ExecutableTest.scala
+++ b/src/test/scala/loamstream/model/execute/ExecutableTest.scala
@@ -7,7 +7,10 @@ import loamstream.model.jobs.JobStatus
 import loamstream.model.jobs.MockJob
 import loamstream.util.Futures
 import loamstream.util.Observables
-import rx.lang.scala.Observable
+import monix.reactive.Observable
+import loamstream.TestHelpers
+import monix.execution.Scheduler
+
 
 /**
  * @author clint
@@ -29,9 +32,9 @@ final class ExecutableTest extends FunSuite {
     val namesObservable = executable.multiplex(names(3))
     
     import Observables.Implicits._
-    import loamstream.TestHelpers.waitFor
+    import Scheduler.Implicits.global
     
-    val actualNames: Seq[String] = waitFor(namesObservable.to[Seq].firstAsFuture).sorted
+    val actualNames: Seq[String] = namesObservable.toListL.runSyncUnsafe(TestHelpers.defaultWaitTime).sorted
     
     assert(actualNames === Seq("A", "A", "A", "B", "B", "B"))
   }

--- a/src/test/scala/loamstream/model/execute/ExecutionStateTest.scala
+++ b/src/test/scala/loamstream/model/execute/ExecutionStateTest.scala
@@ -1,9 +1,11 @@
 package loamstream.model.execute
 
 import org.scalatest.FunSuite
-import loamstream.model.jobs.MockJob
+
 import loamstream.model.jobs.JobStatus
-import loamstream.model.jobs.LJob
+import loamstream.model.jobs.MockJob
+
+import scala.collection.compat._
 
 /**
  * @author clint
@@ -22,7 +24,7 @@ final class ExecutionStateTest extends FunSuite {
     val state = ExecutionState.initialFor(executable, maxRunsPerJob)
     
     assert(state.maxRunsPerJob === maxRunsPerJob)
-    assert(state.allJobs.toSet === Set(j0, j1, j2))
+    assert(state.allJobs.to(Set) === Set(j0, j1, j2))
     
     assert(state.statusOf(j0) === JobStatus.NotStarted)
     assert(state.statusOf(j1) === JobStatus.NotStarted)

--- a/src/test/scala/loamstream/model/execute/MissingOutputsJobFilterTest.scala
+++ b/src/test/scala/loamstream/model/execute/MissingOutputsJobFilterTest.scala
@@ -1,12 +1,15 @@
 package loamstream.model.execute
 
 import org.scalatest.FunSuite
-import loamstream.model.jobs.MockJob
-import loamstream.model.jobs.JobStatus
+
 import loamstream.TestHelpers
 import loamstream.model.jobs.DataHandle
 import loamstream.model.jobs.DataHandle.PathHandle
+import loamstream.model.jobs.JobStatus
+import loamstream.model.jobs.MockJob
 import loamstream.util.Files
+
+import scala.collection.compat._
 
 /**
  * @author clint
@@ -14,7 +17,7 @@ import loamstream.util.Files
  */
 final class MissingOutputsJobFilterTest extends FunSuite {
   import MissingOutputsJobFilter.shouldRun
-  import TestHelpers.path
+  import loamstream.TestHelpers.path
   
   test("shouldRun - no outputs") {
     val j0 = MockJob(JobStatus.Succeeded)
@@ -25,7 +28,7 @@ final class MissingOutputsJobFilterTest extends FunSuite {
   }
   
   test("shouldRun - missing outputs") {
-    val outputs: Set[DataHandle] = Seq("foo/bar/baz/", "/blerg/nerg").map(path).map(PathHandle(_)).toSet
+    val outputs: Set[DataHandle] = Seq("foo/bar/baz/", "/blerg/nerg").map(path).map(PathHandle(_): DataHandle).to(Set)
     
     assert(outputs.forall(_.isMissing))
     
@@ -61,7 +64,7 @@ final class MissingOutputsJobFilterTest extends FunSuite {
         Files.writeTo(p)("sadf")
       }
       
-      val outputs: Set[DataHandle] = paths.map(PathHandle(_)).toSet
+      val outputs: Set[DataHandle] = paths.map(PathHandle(_): DataHandle).to(Set)
       
       assert(outputs.nonEmpty)
       
@@ -109,9 +112,9 @@ final class MissingOutputsJobFilterTest extends FunSuite {
       
       //One missing, two present
 
-      val j1 = MockJob(JobStatus.Succeeded, name = "J1", outputs = outputs.toSet)
+      val j1 = MockJob(JobStatus.Succeeded, name = "J1", outputs = outputs.to(Set))
       
-      assert(j1.outputs === outputs.toSet)
+      assert(j1.outputs === outputs.to(Set))
         
       assert(shouldRun(j1) === true)
     }

--- a/src/test/scala/loamstream/model/execute/MockChunkRunner.scala
+++ b/src/test/scala/loamstream/model/execute/MockChunkRunner.scala
@@ -13,12 +13,12 @@ import monix.reactive.Observable
 final case class MockChunkRunner(delegate: ChunkRunner) extends ChunkRunner {
   override def canRun(job: LJob): Boolean = delegate.canRun(job)
   
-  val chunks: ValueBox[Seq[Set[LJob]]] = ValueBox(Vector.empty)
+  val chunks: ValueBox[Seq[Iterable[LJob]]] = ValueBox(Vector.empty)
   
-  val chunksWithSettings: ValueBox[Seq[Set[(LJob, Settings)]]] = ValueBox(Vector.empty)
+  val chunksWithSettings: ValueBox[Seq[Iterable[(LJob, Settings)]]] = ValueBox(Vector.empty)
 
   override def run(
-      chunk: Set[LJob], 
+      chunk: Iterable[LJob], 
       jobOracle: JobOracle): Observable[(LJob, RunData)] = {
     
     chunks.mutate(_ :+ chunk)

--- a/src/test/scala/loamstream/model/execute/MockChunkRunner.scala
+++ b/src/test/scala/loamstream/model/execute/MockChunkRunner.scala
@@ -3,8 +3,8 @@ package loamstream.model.execute
 import loamstream.model.jobs.LJob
 import loamstream.model.jobs.RunData
 import loamstream.util.ValueBox
-import rx.lang.scala.Observable
 import loamstream.model.jobs.JobOracle
+import monix.reactive.Observable
 
 /**
  * @author clint

--- a/src/test/scala/loamstream/model/execute/ProvidesEnvAndResources.scala
+++ b/src/test/scala/loamstream/model/execute/ProvidesEnvAndResources.scala
@@ -24,6 +24,7 @@ import loamstream.drm.lsf.LsfDefaults
 import loamstream.googlecloud.ClusterConfig
 import loamstream.model.jobs.PseudoExecution
 import loamstream.model.jobs.StoreRecord
+import scala.collection.compat._
 
 /**
  * @author kyuksel
@@ -70,7 +71,7 @@ trait ProvidesEnvAndResources extends FunSuite {
 
   protected def assertEqualFieldsFor(actual: Iterable[Execution.Persisted], expected: Iterable[Execution]): Unit = {
     implicit final class StoreRecordIterableOps(srs: Iterable[StoreRecord]) {
-      def sortedByLoc: Seq[StoreRecord] = srs.toSeq.sortBy(_.loc)
+      def sortedByLoc: Seq[StoreRecord] = srs.to(Seq).sortBy(_.loc)
     }
     
     assert(actual.map(_.envType) === expected.map(_.envType))

--- a/src/test/scala/loamstream/model/execute/ProvidesEnvAndResources.scala
+++ b/src/test/scala/loamstream/model/execute/ProvidesEnvAndResources.scala
@@ -1,29 +1,20 @@
 package loamstream.model.execute
 
-import java.time.Instant
-
 import org.scalatest.FunSuite
 
 import loamstream.TestHelpers
-import loamstream.model.execute.Resources.GoogleResources
-import loamstream.model.execute.Resources.LocalResources
-import loamstream.model.execute.Resources.DrmResources
+import loamstream.drm.lsf.LsfDefaults
+import loamstream.drm.uger.UgerDefaults
+import loamstream.googlecloud.ClusterConfig
 import loamstream.model.jobs.Execution
 import loamstream.model.jobs.JobResult
 import loamstream.model.jobs.JobStatus
-import loamstream.model.quantities.CpuTime
+import loamstream.model.jobs.LJob
+import loamstream.model.jobs.RunData
+import loamstream.model.jobs.StoreRecord
 import loamstream.model.quantities.Cpus
 import loamstream.model.quantities.Memory
-import loamstream.drm.Queue
-import loamstream.model.jobs.RunData
-import loamstream.model.jobs.LJob
-import loamstream.drm.uger.UgerDefaults
-import loamstream.model.execute.Resources.UgerResources
-import loamstream.model.execute.Resources.LsfResources
-import loamstream.drm.lsf.LsfDefaults
-import loamstream.googlecloud.ClusterConfig
-import loamstream.model.jobs.PseudoExecution
-import loamstream.model.jobs.StoreRecord
+
 import scala.collection.compat._
 
 /**
@@ -32,7 +23,7 @@ import scala.collection.compat._
  */
 trait ProvidesEnvAndResources extends FunSuite {
   
-  import TestHelpers.broadQueue
+  import loamstream.TestHelpers.broadQueue
   
   val mockCmd: String = "R --vanilla --args ancestry_pca_scores.tsv < plot_ancestry_pca.r"
   val mockUgerSettings: DrmSettings = UgerDrmSettings(
@@ -46,10 +37,7 @@ trait ProvidesEnvAndResources extends FunSuite {
   val mockExitCode: Int = 999
   val mockResult: JobResult = JobResult.CommandResult(mockExitCode)
 
-  import TestHelpers.{ugerResources => mockUgerResources}
-  import TestHelpers.{lsfResources => mockLsfResources}
-  import TestHelpers.{localResources => mockLocalResources}
-  import TestHelpers.{googleResources => mockGoogleResources}
+  import loamstream.TestHelpers.{ ugerResources => mockUgerResources }
   
   val mockResources: Resources = mockUgerResources
 
@@ -78,7 +66,7 @@ trait ProvidesEnvAndResources extends FunSuite {
     assert(actual.map(_.cmd) === expected.map(_.cmd))
     assert(actual.map(_.status) === expected.map(_.status))
     assert(actual.map(_.result) === expected.map(_.result))
-    // Sort to ignore order whole not forcing evaluation of any lazy fields, which could happen with .toSet
+    // Sort to ignore order whole not forcing evaluation of any lazy fields, which could happen with .to(Set)
     assert(actual.map(_.outputs.sortedByLoc) === expected.map(_.outputs.sortedByLoc)) 
     assert(actual.map(_.jobDir) === expected.map(_.jobDir))
     assert(actual.map(_.terminationReason) === expected.map(_.terminationReason))

--- a/src/test/scala/loamstream/model/execute/RxExecuterTest.scala
+++ b/src/test/scala/loamstream/model/execute/RxExecuterTest.scala
@@ -630,10 +630,10 @@ object RxExecuterTest {
   private final case class MockChunkRunner(delegate: ChunkRunner) extends ChunkRunner {
     override def canRun(job: LJob): Boolean = delegate.canRun(job)
     
-    val chunks: ValueBox[Seq[Set[LJob]]] = ValueBox(Vector.empty)
+    val chunks: ValueBox[Seq[Iterable[LJob]]] = ValueBox(Vector.empty)
 
     override def run(
-        jobs: Set[LJob], 
+        jobs: Iterable[LJob], 
         jobOracle: JobOracle): Observable[(LJob, RunData)] = {
       
       chunks.mutate(_ :+ jobs)

--- a/src/test/scala/loamstream/model/execute/RxExecuterTest.scala
+++ b/src/test/scala/loamstream/model/execute/RxExecuterTest.scala
@@ -14,6 +14,7 @@ import loamstream.model.jobs.RunData
 import loamstream.model.jobs.RxMockJob
 import loamstream.util.ValueBox
 import monix.reactive.Observable
+import scala.collection.compat._
 
 
 /**
@@ -357,7 +358,7 @@ final class RxExecuterTest extends FunSuite {
       
       assert(result.size === 2)
       
-      val expectedChunks: Seq[Set[RxMockJob]] = Set(job1) +: (0 until expectedRuns2).toSeq.map(_ => Set(job2))
+      val expectedChunks: Seq[Set[RxMockJob]] = Set(job1) +: (0 until expectedRuns2).to(Seq).map(_ => Set(job2))
       
       assert(chunks === expectedChunks)
       
@@ -414,7 +415,7 @@ final class RxExecuterTest extends FunSuite {
       assert(result.size === expectedNumResults)
       
       val expectedChunks = {
-        val expectedChunksForJob2 = (0 until expectedRuns2).toSeq.map(_ => Set(job2))
+        val expectedChunksForJob2 = (0 until expectedRuns2).to(Seq).map(_ => Set(job2))
         val expectedChunksForJobs1And2 = Set(job1) +: expectedChunksForJob2
         
         if(job3ShouldFail) { expectedChunksForJobs1And2 } 

--- a/src/test/scala/loamstream/model/execute/RxExecuterTest.scala
+++ b/src/test/scala/loamstream/model/execute/RxExecuterTest.scala
@@ -13,7 +13,7 @@ import loamstream.model.jobs.LJob
 import loamstream.model.jobs.RunData
 import loamstream.model.jobs.RxMockJob
 import loamstream.util.ValueBox
-import rx.lang.scala.Observable
+import monix.reactive.Observable
 
 
 /**

--- a/src/test/scala/loamstream/model/execute/SuccessfulOutputsExecutionRecorderTest.scala
+++ b/src/test/scala/loamstream/model/execute/SuccessfulOutputsExecutionRecorderTest.scala
@@ -53,7 +53,7 @@ final class SuccessfulOutputsExecutionRecorderTest extends FunSuite {
       
       assert(exists(file) === true)
       
-      val recordedLocs = Files.readFrom(file).split(System.lineSeparator).iterator.map(_.trim).toSet
+      val recordedLocs = Files.readFrom(file).split(System.lineSeparator).iterator.map(_.trim).to(Set)
       
       val expected = for {
         job <- Seq(j0, j2, j3, j4)
@@ -62,7 +62,7 @@ final class SuccessfulOutputsExecutionRecorderTest extends FunSuite {
         s"${job.toReturn.jobStatus}\t${output.location}"
       }
       
-      assert(recordedLocs === expected.toSet)
+      assert(recordedLocs === expected.to(Set))
     }
   }
 }

--- a/src/test/scala/loamstream/model/execute/SuccessfulOutputsExecutionRecorderTest.scala
+++ b/src/test/scala/loamstream/model/execute/SuccessfulOutputsExecutionRecorderTest.scala
@@ -8,6 +8,7 @@ import loamstream.model.jobs.Execution
 import loamstream.model.jobs.JobStatus
 import loamstream.model.jobs.MockJob
 import loamstream.util.Files
+import scala.collection.compat._
 
 /**
  * @author clint
@@ -56,7 +57,7 @@ final class SuccessfulOutputsExecutionRecorderTest extends FunSuite {
       
       val expected = for {
         job <- Seq(j0, j2, j3, j4)
-        output <- job.outputs.toSeq
+        output <- job.outputs.to(Seq)
       } yield {
         s"${job.toReturn.jobStatus}\t${output.location}"
       }

--- a/src/test/scala/loamstream/util/DirTreeTest.scala
+++ b/src/test/scala/loamstream/util/DirTreeTest.scala
@@ -15,6 +15,7 @@ import loamstream.model.jobs.JobStatus
 import loamstream.model.jobs.LJob
 import loamstream.model.jobs.MockJob
 import loamstream.model.jobs.RunData
+import scala.collection.compat._
 
 /**
  * @author clint
@@ -376,7 +377,7 @@ final class DirTreeTest extends FunSuite {
     
     val branchingFactor = 500
     
-    val node = DirTree.allocate(jobs.toSeq, branchingFactor)
+    val node = DirTree.allocate(jobs.to(Seq), branchingFactor)
     
     assert(node.isInstanceOf[Interior[_]])
     
@@ -395,7 +396,7 @@ final class DirTreeTest extends FunSuite {
     
     val branchingFactor = 10
     
-    val node: DirNode[LJob] = DirTree.allocate(jobs.toSeq, branchingFactor)
+    val node: DirNode[LJob] = DirTree.allocate(jobs.to(Seq), branchingFactor)
     
     val root = node.asInstanceOf[Interior[_]]
     

--- a/src/test/scala/loamstream/util/DirTreeTest.scala
+++ b/src/test/scala/loamstream/util/DirTreeTest.scala
@@ -415,8 +415,8 @@ final class DirTreeTest extends FunSuite {
     val lhsLeaves = leftBranch.children.map(_.asInstanceOf[DirNode.Leaf[LJob]])
     val rhsLeaves = rightBranch.children.map(_.asInstanceOf[DirNode.Leaf[LJob]])
     
-    assert(lhsLeaves.map(_.value.name).toSet === (0 to 9).map(_.toString).toSet)
-    assert(rhsLeaves.map(_.value.name).toSet === Set("10"))
+    assert(lhsLeaves.map(_.value.name).to(Set) === (0 to 9).map(_.toString).to(Set))
+    assert(rhsLeaves.map(_.value.name).to(Set) === Set("10"))
   }
 }
 

--- a/src/test/scala/loamstream/util/FileMonitorTest.scala
+++ b/src/test/scala/loamstream/util/FileMonitorTest.scala
@@ -5,6 +5,7 @@ import loamstream.TestHelpers
 import java.nio.file.{ Files => JFiles }
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
+import scala.collection.compat._
 
 /**
  * @author clint
@@ -148,7 +149,7 @@ final class FileMonitorTest extends FunSuite {
     
     val futures = (1 to 5).map(_ => fileMonitor.waitForCreationOf(initiallyNonExistantFile))
     
-    val watchers = fileMonitor.getWatchedFiles(initiallyNonExistantFile).toSeq
+    val watchers = fileMonitor.getWatchedFiles(initiallyNonExistantFile).to(Seq)
     
     assert(watchers.size === 5)
     
@@ -195,7 +196,7 @@ final class FileMonitorTest extends FunSuite {
     
     val futures = (1 to 5).map(_ => fileMonitor.waitForCreationOf(fileThatNeverAppears))
     
-    val watchers = fileMonitor.getWatchedFiles(fileThatNeverAppears).toSeq
+    val watchers = fileMonitor.getWatchedFiles(fileThatNeverAppears).to(Seq)
     
     assert(watchers.size === 5)
     

--- a/src/test/scala/loamstream/util/FilesTest.scala
+++ b/src/test/scala/loamstream/util/FilesTest.scala
@@ -1,14 +1,17 @@
 package loamstream.util
 
 import java.nio.charset.StandardCharsets
+import java.nio.file.{ Files => JFiles }
 import java.nio.file.Path
-import java.nio.file.{Files => JFiles}
-
-import org.scalatest.FunSuite
 
 import scala.collection.JavaConverters.asScalaIteratorConverter
 import scala.util.Success
+
+import org.scalatest.FunSuite
+
 import loamstream.TestHelpers
+
+import scala.collection.compat._
 
 /**
   * @author clint
@@ -16,8 +19,8 @@ import loamstream.TestHelpers
   */
 final class FilesTest extends FunSuite {
   import Paths.Implicits._
-  import TestHelpers.path
   import java.nio.file.Files.exists
+  import loamstream.TestHelpers.path
   
   test("copyAndOverwrite") {
     TestHelpers.withWorkDir(getClass.getSimpleName) { workDir =>
@@ -102,9 +105,9 @@ final class FilesTest extends FunSuite {
     assert(Files.listFiles(dummy, ".*") === List(dummyFile1))
 
     val dummyFile2 = Files.tempFile(dummyFileSuffix, dummy.toFile).toFile
-    assert(Files.listFiles(dummy, ".*").toSet === Set(dummyFile1, dummyFile2))
-    assert(Files.listFiles(dummy, ".*dummy.*").toSet === Set(dummyFile1, dummyFile2))
-    assert(Files.listFiles(dummy, ".*duMMy.*").toSet === Set.empty)
+    assert(Files.listFiles(dummy, ".*").to(Set) === Set(dummyFile1, dummyFile2))
+    assert(Files.listFiles(dummy, ".*dummy.*").to(Set) === Set(dummyFile1, dummyFile2))
+    assert(Files.listFiles(dummy, ".*duMMy.*").to(Set) === Set.empty)
 
     assert(dummyFile1.delete)
     assert(dummyFile2.delete)

--- a/src/test/scala/loamstream/util/ObservablesTest.scala
+++ b/src/test/scala/loamstream/util/ObservablesTest.scala
@@ -12,6 +12,7 @@ import loamstream.TestHelpers
 import monix.reactive.subjects.Subject
 import monix.execution.Ack
 
+import scala.collection.compat._
 
 
 /**
@@ -137,28 +138,28 @@ final class ObservablesTest extends FunSuite {
   test("until") {
     def observable = Observable(2, 4, 6, 7, 8, 9, 10) 
 
-    def toSeq[A](o: Observable[A]): Seq[A] = o.toListL.runSyncUnsafe(TestHelpers.defaultWaitTime)
+    def asSeq[A](o: Observable[A]): Seq[A] = o.toListL.runSyncUnsafe(TestHelpers.defaultWaitTime)
     
     {
-      val is = toSeq(observable.until(isOdd))
+      val is = asSeq(observable.until(isOdd))
 
       assert(is == Seq(2, 4, 6, 7)) 
     }
 
     {
-      val is = toSeq(observable.until(isEven))
+      val is = asSeq(observable.until(isEven))
 
       assert(is == Seq(2))
     }
 
     {
-      val is = toSeq(observable.until(_ == 8))
+      val is = asSeq(observable.until(_ == 8))
 
       assert(is == Seq(2, 4, 6, 7, 8)) 
     }
 
     {
-      val is = toSeq(observable.until(_ == 42))
+      val is = asSeq(observable.until(_ == 42))
 
       assert(is == Seq(2, 4, 6, 7, 8, 9, 10)) 
     }

--- a/src/test/scala/loamstream/util/ObservablesTest.scala
+++ b/src/test/scala/loamstream/util/ObservablesTest.scala
@@ -21,7 +21,6 @@ import monix.execution.Ack
 final class ObservablesTest extends FunSuite {
   
   import Observables.Implicits._
-  import Observables.sequence
   import loamstream.TestHelpers.waitFor
   
   private def isEven(i: Int): Boolean = i % 2 == 0
@@ -36,73 +35,6 @@ final class ObservablesTest extends FunSuite {
   }
   
   private implicit val scheduler = Scheduler.global
-  
-  test("sequence") {
-    val a = "A"
-    val b = "B"
-    val c = "C"
-    
-    val os: Seq[Observable[String]] = Seq(makeObservable(50, a), makeObservable(200, b), makeObservable(100, c))
-    
-    val future = sequence(os).take(1).lastAsFuture
-    
-    val actual = waitFor(future)
-    
-    //Use a set to ignore order
-    assert(actual.toSet == Set(a, b, c))
-  }
-  
-  test("sequence - multiple events") {
-    val a = "A"
-    val b = "B"
-    val c = "C"
-    
-    val x = "X"
-    val y = "Y"
-    val z = "Z"
-    
-    val os: Seq[Observable[String]] = Seq(
-        makeObservable(50, a, x), 
-        makeObservable(200, b, y), 
-        makeObservable(100, c, z))
-    
-    val actual = sequence(os).map(_.toSet).take(2).toListL.runSyncUnsafe(TestHelpers.defaultWaitTime)
-    
-    //Use sets to ignore order
-    val expected = Seq(Set(a,b,c), Set(x,y,z))
-    
-    assert(actual == expected)
-  }
-  
-  test("sequence - multiple events, no delays") {
-    val a = "A"
-    val b = "B"
-    val c = "C"
-    
-    val x = "X"
-    val y = "Y"
-    val z = "Z"
-    
-    val os: Seq[Observable[String]] = Seq(makeObservable(0, a, x), makeObservable(0, b, y), makeObservable(0, c, z))
-    
-    val actual = sequence(os).map(_.toSet).take(2).toListL.runSyncUnsafe(TestHelpers.defaultWaitTime)
-    
-    //Use sets to ignore order
-    val expected = Seq(Set(a,b,c), Set(x,y,z))
-    
-    assert(actual == expected)
-  }
-
-  test("sequence (empty input)") {
-    
-    val os: Seq[Observable[String]] = Nil
-    
-    val future = sequence(os).take(1).lastAsFuture
-    
-    val actual = waitFor(future)
-    
-    assert(actual == Nil)
-  }
   
   test("observeAsync") {
     import scala.concurrent.ExecutionContext.Implicits.global

--- a/src/test/scala/loamstream/util/ObservablesTest.scala
+++ b/src/test/scala/loamstream/util/ObservablesTest.scala
@@ -1,13 +1,17 @@
 package loamstream.util
 
 import scala.concurrent.Future
-import scala.concurrent.duration.DurationInt
+import scala.concurrent.duration._
 
 import org.scalatest.FunSuite
 
-import rx.lang.scala.Observable
-import rx.lang.scala.Subject
-import rx.lang.scala.subjects.PublishSubject
+import monix.reactive.Observable
+import monix.reactive.subjects.PublishSubject
+import monix.execution.Scheduler
+import loamstream.TestHelpers
+import monix.reactive.subjects.Subject
+import monix.execution.Ack
+
 
 
 /**
@@ -16,9 +20,9 @@ import rx.lang.scala.subjects.PublishSubject
  */
 final class ObservablesTest extends FunSuite {
   
-  import loamstream.TestHelpers.waitFor
   import Observables.Implicits._
   import Observables.sequence
+  import loamstream.TestHelpers.waitFor
   
   private def isEven(i: Int): Boolean = i % 2 == 0
   private def isOdd(i: Int): Boolean = !isEven(i)
@@ -27,11 +31,11 @@ final class ObservablesTest extends FunSuite {
     if(period == 0) {
       Observable.from(msgs)
     } else {
-      import scala.concurrent.duration._
-      
-      Observable.interval(period.milliseconds).zip(msgs).collect { case (_, msg) => msg }
+      Observable.interval(period.milliseconds).zip(Observable.fromIterable(msgs)).collect { case (_, msg) => msg }
     }
   }
+  
+  private implicit val scheduler = Scheduler.global
   
   test("sequence") {
     val a = "A"
@@ -62,9 +66,7 @@ final class ObservablesTest extends FunSuite {
         makeObservable(200, b, y), 
         makeObservable(100, c, z))
     
-    val future = sequence(os).map(_.toSet).take(2).to[Seq].lastAsFuture
-    
-    val actual = waitFor(future)
+    val actual = sequence(os).map(_.toSet).take(2).toListL.runSyncUnsafe(TestHelpers.defaultWaitTime)
     
     //Use sets to ignore order
     val expected = Seq(Set(a,b,c), Set(x,y,z))
@@ -83,9 +85,7 @@ final class ObservablesTest extends FunSuite {
     
     val os: Seq[Observable[String]] = Seq(makeObservable(0, a, x), makeObservable(0, b, y), makeObservable(0, c, z))
     
-    val future = sequence(os).map(_.toSet).take(2).to[Seq].lastAsFuture
-    
-    val actual = waitFor(future)
+    val actual = sequence(os).map(_.toSet).take(2).toListL.runSyncUnsafe(TestHelpers.defaultWaitTime)
     
     //Use sets to ignore order
     val expected = Seq(Set(a,b,c), Set(x,y,z))
@@ -109,9 +109,9 @@ final class ObservablesTest extends FunSuite {
     
     val o = Observables.observeAsync(42)
     
-    val future = o.to[Seq].firstAsFuture
+    val actual = o.toListL.runSyncUnsafe(TestHelpers.defaultWaitTime)
     
-    assert(waitFor(future) == Seq(42))
+    assert(actual === Seq(42))
   }
   
   test("observeAsync - exception thrown") {
@@ -130,17 +130,17 @@ final class ObservablesTest extends FunSuite {
     assert(waitFor(toMap(Nil).lastAsFuture) == Map.empty)
     
     {
-      val tuples = Seq("a" -> Observable.just(1), "b" -> Observable.just(2), "c" -> Observable.just(3))
+      val tuples = Seq("a" -> Observable(1), "b" -> Observable(2), "c" -> Observable(3))
       
       assert(waitFor(toMap(tuples).lastAsFuture) == Map("a" -> 1, "b" -> 2, "c" -> 3))
     }
     
     {
-      val tuples = Seq("a" -> Observable.just(1), "b" -> Observable.just(2, 22), "c" -> Observable.just(3))
+      val tuples = Seq("a" -> Observable(1), "b" -> Observable(2, 22), "c" -> Observable(3))
 
       val expected = Seq(Map("a" -> 1, "b" -> 22, "c" -> 3))
       
-      assert(waitFor(toMap(tuples).to[Seq].firstAsFuture) == expected)
+      assert(toMap(tuples).toListL.runSyncUnsafe(TestHelpers.defaultWaitTime) == expected)
     }
   }
   
@@ -180,7 +180,7 @@ final class ObservablesTest extends FunSuite {
       Observable.from(strs)
     }
     
-    val strs = waitFor(merge(os).to[Seq].firstAsFuture)
+    val strs = merge(os).toListL.runSyncUnsafe(TestHelpers.defaultWaitTime)
     
     val expected = Seq(
         "a", 
@@ -203,32 +203,32 @@ final class ObservablesTest extends FunSuite {
   }
   
   test("until") {
-    def observable = Observable.just(2, 4, 6, 7, 8, 9, 10) 
+    def observable = Observable(2, 4, 6, 7, 8, 9, 10) 
 
-    def toFuture[A](o: Observable[A]): Future[Seq[A]] = o.to[Seq].firstAsFuture
+    def toSeq[A](o: Observable[A]): Seq[A] = o.toListL.runSyncUnsafe(TestHelpers.defaultWaitTime)
     
     {
-      val fut = toFuture(observable.until(isOdd))
+      val is = toSeq(observable.until(isOdd))
 
-      assert(waitFor(fut) == Seq(2, 4, 6, 7)) 
+      assert(is == Seq(2, 4, 6, 7)) 
     }
 
     {
-      val fut = toFuture(observable.until(isEven))
+      val is = toSeq(observable.until(isEven))
 
-      assert(waitFor(fut) == Seq(2))
+      assert(is == Seq(2))
     }
 
     {
-      val fut = toFuture(observable.until(_ == 8))
+      val is = toSeq(observable.until(_ == 8))
 
-      assert(waitFor(fut) == Seq(2, 4, 6, 7, 8)) 
+      assert(is == Seq(2, 4, 6, 7, 8)) 
     }
 
     {
-      val fut = toFuture(observable.until(_ == 42))
+      val is = toSeq(observable.until(_ == 42))
 
-      assert(waitFor(fut) == Seq(2, 4, 6, 7, 8, 9, 10)) 
+      assert(is == Seq(2, 4, 6, 7, 8, 9, 10)) 
     }
   }
   
@@ -239,14 +239,18 @@ final class ObservablesTest extends FunSuite {
     assert(e1 !== e2)
     
     def doTest(toThrow: Throwable, expected: Option[Throwable]): Unit = { 
-      val source: Subject[Int] = PublishSubject[Int]()
+      val source: Subject[Int, Int] = PublishSubject[Int]()
       
       val limited = source.until(_ == 42)
       
       val current: ValueBox[Int] = ValueBox(0)
       val currentException: ValueBox[Option[Throwable]] = ValueBox(None)
       
-      def onNext(i: Int): Unit = current := i
+      def onNext(i: Int): Future[Ack] = {
+        current := i
+        
+        Ack.Continue
+      }
       
       def onError(t: Throwable): Unit = {
         if(t.getMessage == "blarg") { currentException := Some(t) } else { currentException := None }
@@ -276,13 +280,15 @@ final class ObservablesTest extends FunSuite {
     def doTest(completeEarly: Boolean = true): Unit = {
       val completed: ValueBox[Boolean] = ValueBox(false)
       
-      val source: Subject[Int] = PublishSubject[Int]()
+      val source: Subject[Int, Int] = PublishSubject[Int]()
         
       val limited = source.until(_ == 42)
       
       def noop[A]: A => Unit = _ => ()
       
-      limited.subscribe(noop, noop, () => completed := true)
+      def onNext[A]: A => Future[Ack] = _ => Ack.Continue
+      
+      limited.subscribe(onNext, noop, () => completed := true)
       
       assert(completed() === false)
       
@@ -291,7 +297,7 @@ final class ObservablesTest extends FunSuite {
       assert(completed() === false)
       
       if(completeEarly) {
-        source.onCompleted()
+        source.onComplete()
       } else {
         source.onNext(42)
       }
@@ -304,13 +310,13 @@ final class ObservablesTest extends FunSuite {
   }
 
   test("firstAsFuture") {
-    val f = Observable.just("a", "b", "c", "d").firstAsFuture
+    val f = Observable("a", "b", "c", "d").firstAsFuture
 
     assert(waitFor(f) == "a")
   }
 
   test("lastAsFuture") {
-    val f = Observable.just("a", "b", "c", "d").lastAsFuture
+    val f = Observable("a", "b", "c", "d").lastAsFuture
 
     assert(waitFor(f) == "d")
   }

--- a/src/test/scala/loamstream/util/SequenceTest.scala
+++ b/src/test/scala/loamstream/util/SequenceTest.scala
@@ -2,6 +2,8 @@ package loamstream.util
 
 import org.scalatest.FunSuite
 
+import scala.collection.compat._
+
 /**
  * @author clint
  * date: Aug 12, 2016
@@ -12,7 +14,7 @@ final class SequenceTest extends FunSuite {
     {
       val is: Sequence[Int] = Sequence()
       
-      val first5 = is.iterator.take(5).toList
+      val first5 = is.iterator.take(5).to(List)
       
       assert(first5 == Seq(0,1,2,3,4))
     }
@@ -20,7 +22,7 @@ final class SequenceTest extends FunSuite {
     {
       val ls: Sequence[Long] = Sequence()
       
-      val first5 = ls.iterator.take(5).toList
+      val first5 = ls.iterator.take(5).to(List)
       
       assert(first5 == Seq(0L,1L,2L,3L,4L))
     }
@@ -30,7 +32,7 @@ final class SequenceTest extends FunSuite {
     {
       val is: Sequence[Int] = Sequence(5, 3)
       
-      val first5 = is.iterator.take(5).toList
+      val first5 = is.iterator.take(5).to(List)
       
       assert(first5 == Seq(5,8,11,14,17))
     }
@@ -38,7 +40,7 @@ final class SequenceTest extends FunSuite {
     {
       val ls: Sequence[Long] = Sequence(5L, 3L)
       
-      val first5 = ls.iterator.take(5).toList
+      val first5 = ls.iterator.take(5).to(List)
       
       assert(first5 == Seq(5L,8L,11L,14L,17L))
     }
@@ -48,7 +50,7 @@ final class SequenceTest extends FunSuite {
     {
       val is: Sequence[Int] = Sequence(-5, 3)
       
-      val first5 = is.iterator.take(5).toList
+      val first5 = is.iterator.take(5).to(List)
       
       assert(first5 == Seq(-5,-2,1,4,7))
     }
@@ -56,7 +58,7 @@ final class SequenceTest extends FunSuite {
     {
       val is: Sequence[Int] = Sequence(5, -3)
       
-      val first5 = is.iterator.take(5).toList
+      val first5 = is.iterator.take(5).to(List)
       
       assert(first5 == Seq(5,2,-1,-4,-7))
     }
@@ -64,7 +66,7 @@ final class SequenceTest extends FunSuite {
     {
       val is: Sequence[Int] = Sequence(-5, -3)
       
-      val first5 = is.iterator.take(5).toList
+      val first5 = is.iterator.take(5).to(List)
       
       assert(first5 == Seq(-5,-8,-11,-14,-17))
     }

--- a/src/test/scala/loamstream/util/TraversablesTest.scala
+++ b/src/test/scala/loamstream/util/TraversablesTest.scala
@@ -2,6 +2,8 @@ package loamstream.util
 
 import org.scalatest.FunSuite
 
+import scala.collection.compat._
+
 /**
  * @author clint
  * date: Aug 11, 2016
@@ -17,7 +19,7 @@ final class TraversablesTest extends FunSuite {
   test("splitOn") {
     import Traversables.Implicits._
     
-    def split(t: Traversable[Char]): List[String] = t.splitOn(_ == '-').toList.map(_.mkString)
+    def split(t: Traversable[Char]): List[String] = t.splitOn(_ == '-').to(List).map(_.mkString)
     
     assert(split("abc-tuv-xyz-".toTraversable) === List("abc", "tuv", "xyz"))
     assert(split("-abc-tuv-xyz".toTraversable) === List("abc", "tuv", "xyz"))

--- a/src/test/scala/loamstream/util/jvm/JvmArgsTest.scala
+++ b/src/test/scala/loamstream/util/jvm/JvmArgsTest.scala
@@ -3,6 +3,7 @@ package loamstream.util.jvm
 import org.scalatest.FunSuite
 import java.nio.file.Paths
 import loamstream.cli.Conf
+import scala.collection.compat._
 
 /**
  * @author clint
@@ -27,7 +28,7 @@ final class JvmArgsTest extends FunSuite {
     val sysprop0 = "-Dx=123"
     val sysprop1 = "-Dy=456"
     
-    val args = "--conf foo.conf --backend uger --run everything --loams u.loam v.loam".split("\\s+").toList
+    val args = "--conf foo.conf --backend uger --run everything --loams u.loam v.loam".split("\\s+").to(List)
     
     val expected = Seq(
         expectedJavaBinary.toString,


### PR DESCRIPTION
RxScala is built for Scala 2.13, but is unmaintained and targets an old RxJava release (1.x).  Monix is robust and much better supported.  Mostly, this was a drop-in replacement.

- Profiling showed near-identical CPU and memory usage.
- Smoke tests by @ClintAtTheBroad  and @rmkoesterer worked fine.

