### PR TITLE
Fix variant column inference and data type of uploaded pvalues

### DIFF
--- a/src/main/scala/loamstream/loam/intake/VariantRowExpr.scala
+++ b/src/main/scala/loamstream/loam/intake/VariantRowExpr.scala
@@ -264,22 +264,22 @@ object VariantRowExpr extends Loggable {
           _.inferMaf,
           _.inferN)
           
-      inferenceFns.foldLeft(this) { (acc, f) => 
+      val inferred = inferenceFns.foldLeft(this) { (acc, f) => 
         f(acc)
       }
       
       def msg(column: String) = s"Column '${column}' wasn't defined and couldn't be computed from other columns"
       
-      require(nDef.isDefined, msg("n")) 
+      require(inferred.nDef.isDefined, msg("n")) 
     
       PValueRowColumnDefs(
-        zscoreDef = zscoreDef,
-        stderrDef = stderrDef,
-        betaDef = betaDef,
-        oddsRatioDef = oddsRatioDef,
-        eafDef = eafDef,
-        mafDef = mafDef,
-        nDef = nDef.get)
+        zscoreDef = inferred.zscoreDef,
+        stderrDef = inferred.stderrDef,
+        betaDef = inferred.betaDef,
+        oddsRatioDef = inferred.oddsRatioDef,
+        eafDef = inferred.eafDef,
+        mafDef = inferred.mafDef,
+        nDef = inferred.nDef.get)
     }
   }
 }

--- a/src/main/scala/loamstream/loam/intake/rows.scala
+++ b/src/main/scala/loamstream/loam/intake/rows.scala
@@ -273,7 +273,7 @@ object PValueVariantRow {
       
       BaseVariantRow.commonJson(row) ++
       Seq(
-        AggregatorJsonKeys.pValue -> JString(pvalue.toString),
+        AggregatorJsonKeys.pValue -> JDouble(pvalue),
         AggregatorJsonKeys.beta -> toJson(beta),
         AggregatorJsonKeys.oddsRatio -> toJson(oddsRatio),
         AggregatorJsonKeys.eaf -> toJson(eaf),


### PR DESCRIPTION
- Actually use inferred column definitions in VariantRowExpr 
- Treat pvalues as doubles and not strings in PValueVariantRow when making JSON