### PR TITLE
Address BCH Slurm Woes

### DIFF
--- a/src/main/scala/loamstream/drm/DrmChunkRunner.scala
+++ b/src/main/scala/loamstream/drm/DrmChunkRunner.scala
@@ -232,11 +232,11 @@ object DrmChunkRunner extends Loggable {
       val statusDescription = s"${simpleNameOf[DrmStatus]} ${s}"
       
       if(s.isFinished && notSuccess(s)) {
-        debug(s"For task ${taskId}, ${statusDescription} is finished and NOT a success, determining execution node and queue: $s")
-        
+        debug(s"For task ${taskId}, ${statusDescription} is finished and NOT a success, getting accounting info")
+
         getAccountingInfoFor(accountingClient)(taskId)
       } else {
-        debug(s"For task ${taskId}, ${statusDescription} is NOT finished or is a success, NOT determining execution node and queue: $s")
+        debug(s"For task ${taskId}, ${statusDescription} is NOT finished or is a success, NOT getting accounting info")
         
         Task.now(None)
       }

--- a/src/main/scala/loamstream/drm/DrmChunkRunner.scala
+++ b/src/main/scala/loamstream/drm/DrmChunkRunner.scala
@@ -232,11 +232,11 @@ object DrmChunkRunner extends Loggable {
       val statusDescription = s"${simpleNameOf[DrmStatus]} ${s}"
       
       if(s.isFinished && notSuccess(s)) {
-        debug(s"${statusDescription} is finished and NOT a success, determining execution node and queue: $s")
+        debug(s"For task ${taskId}, ${statusDescription} is finished and NOT a success, determining execution node and queue: $s")
         
         getAccountingInfoFor(accountingClient)(taskId)
       } else {
-        debug(s"${statusDescription} is NOT finished or is a success, NOT determining execution node and queue: $s")
+        debug(s"For task ${taskId}, ${statusDescription} is NOT finished or is a success, NOT determining execution node and queue: $s")
         
         Task.now(None)
       }

--- a/src/main/scala/loamstream/drm/DrmJobWrapper.scala
+++ b/src/main/scala/loamstream/drm/DrmJobWrapper.scala
@@ -100,21 +100,21 @@ final case class DrmJobWrapper(
         |STDOUT_FILE="${stdOutDestPath.render}"
         |STDERR_FILE="${stdErrDestPath.render}"
         |
-        |echo "Node: $$(hostname)" >> $$STATS_FILE
-        |echo Task_Array_Name: ${taskArray.drmJobName} >> $$STATS_FILE
-        |echo DRM_Task_Id: "$${jobId}-$${i}" >> $$STATS_FILE
-        |echo "Raw_Logs: .loamstream/${drmWorkSubDir}/${taskArray.drmJobName}/$${i}.{stdout,stderr}" >> $$STATS_FILE
+        |stdbuf -oL echo "Node: $$(hostname)" >> $$STATS_FILE
+        |stdbuf -oL echo Task_Array_Name: ${taskArray.drmJobName} >> $$STATS_FILE
+        |stdbuf -oL echo DRM_Task_Id: "$${jobId}-$${i}" >> $$STATS_FILE
+        |stdbuf -oL echo "Raw_Logs: .loamstream/${drmWorkSubDir}/${taskArray.drmJobName}/$${i}.{stdout,stderr}" >> $$STATS_FILE
         |
         |START="$$(${timestampCommand})"
-        |echo "Start: $$START" >> $$STATS_FILE
         |
         |${timePrefixPart} bash $$COMMAND_SCRIPT 1> $$STDOUT_FILE 2> $$STDERR_FILE
         |
         |LOAMSTREAM_JOB_EXIT_CODE=$$?
         |
-        |echo "$$LOAMSTREAM_JOB_EXIT_CODE" > $$EXITCODE_FILE
+        |stdbuf -oL echo "$$LOAMSTREAM_JOB_EXIT_CODE" > $$EXITCODE_FILE
         |
-        |echo "End: $$(${timestampCommand})" >> $$STATS_FILE
+        |stdbuf -oL echo "Start: $$START" >> $$STATS_FILE
+        |stdbuf -oL echo "End: $$(${timestampCommand})" >> $$STATS_FILE
         |
         |exit $$LOAMSTREAM_JOB_EXIT_CODE
         |""".stripMargin

--- a/src/main/scala/loamstream/drm/DrmJobWrapper.scala
+++ b/src/main/scala/loamstream/drm/DrmJobWrapper.scala
@@ -100,10 +100,10 @@ final case class DrmJobWrapper(
         |STDOUT_FILE="${stdOutDestPath.render}"
         |STDERR_FILE="${stdErrDestPath.render}"
         |
-        |stdbuf -oL echo "Node: $$(hostname)" >> $$STATS_FILE
-        |stdbuf -oL echo Task_Array_Name: ${taskArray.drmJobName} >> $$STATS_FILE
-        |stdbuf -oL echo DRM_Task_Id: "$${jobId}-$${i}" >> $$STATS_FILE
-        |stdbuf -oL echo "Raw_Logs: .loamstream/${drmWorkSubDir}/${taskArray.drmJobName}/$${i}.{stdout,stderr}" >> $$STATS_FILE
+        |echo "Node: $$(hostname)" >> $$STATS_FILE
+        |echo Task_Array_Name: ${taskArray.drmJobName} >> $$STATS_FILE
+        |echo DRM_Task_Id: "$${jobId}-$${i}" >> $$STATS_FILE
+        |echo "Raw_Logs: .loamstream/${drmWorkSubDir}/${taskArray.drmJobName}/$${i}.{stdout,stderr}" >> $$STATS_FILE
         |
         |START="$$(${timestampCommand})"
         |
@@ -111,10 +111,10 @@ final case class DrmJobWrapper(
         |
         |LOAMSTREAM_JOB_EXIT_CODE=$$?
         |
-        |stdbuf -oL echo "$$LOAMSTREAM_JOB_EXIT_CODE" > $$EXITCODE_FILE
+        |echo "$$LOAMSTREAM_JOB_EXIT_CODE" > $$EXITCODE_FILE
         |
-        |stdbuf -oL echo "Start: $$START" >> $$STATS_FILE
-        |stdbuf -oL echo "End: $$(${timestampCommand})" >> $$STATS_FILE
+        |echo "Start: $$START" >> $$STATS_FILE
+        |echo "End: $$(${timestampCommand})" >> $$STATS_FILE
         |
         |exit $$LOAMSTREAM_JOB_EXIT_CODE
         |""".stripMargin

--- a/src/main/scala/loamstream/drm/RateLimitedPoller.scala
+++ b/src/main/scala/loamstream/drm/RateLimitedPoller.scala
@@ -94,10 +94,8 @@ abstract class RateLimitedPoller[P](
     }
 
     val statusObs = {
-      existingExitCodeFileObs.flatMap(readFromExitCodeFile) //++
-      //existingStatsFileObs.flatMap(readFromStatsFile)
+      existingExitCodeFileObs.flatMap(readFromExitCodeFile)
     }.headOrElse {
-      //error(s"Looked for ${(exitCodeFile.toSeq ++ statsFile).mkString(",")} , none of which could be found.")
       error(s"Treating ${taskId} as ${DrmStatus.Failed} ; waited for ${exitCodeFile}, but it didn't appear.")
 
       DrmStatus.Failed

--- a/src/main/scala/loamstream/drm/RateLimitedPoller.scala
+++ b/src/main/scala/loamstream/drm/RateLimitedPoller.scala
@@ -93,11 +93,12 @@ abstract class RateLimitedPoller[P](
       Observable.fromIterable(readExitCodeFromExitCodeFile(file))
     }
 
-    val statusObs = Observables.merge(
-      existingStatsFileObs.flatMap(readFromStatsFile),
-      existingExitCodeFileObs.flatMap(readFromExitCodeFile)
-    ).headOrElse {
-      error(s"Looked for ${(exitCodeFile.toSeq ++ statsFile).mkString(",")} , none of which could be found.")
+    val statusObs = {
+      existingExitCodeFileObs.flatMap(readFromExitCodeFile) //++
+      //existingStatsFileObs.flatMap(readFromStatsFile)
+    }.headOrElse {
+      //error(s"Looked for ${(exitCodeFile.toSeq ++ statsFile).mkString(",")} , none of which could be found.")
+      error(s"Treating ${taskId} as ${DrmStatus.Failed} ; waited for ${exitCodeFile}, but it didn't appear.")
 
       DrmStatus.Failed
     }

--- a/src/main/scala/loamstream/loam/intake/dga/Json.scala
+++ b/src/main/scala/loamstream/loam/intake/dga/Json.scala
@@ -16,17 +16,29 @@ import scala.collection.compat._
  * Jan 20, 2021
  */
 object Json {
+  private object Number {
+    def unapply[A](a: A): Option[JValue] = {
+      import org.json4s.JsonDSL._
+
+      //TODO: There must be a better way :(
+      a match {
+        case l: Long => Some(l)
+        case i: Int => Some(i)
+        case d: Double => Some(d)
+        case f: Float => Some(f)
+        case bd: BigDecimal => Some(bd)
+        case _ => None
+      }
+    }
+  }
+
   def toJValue[A](a: A): JValue = {
     import org.json4s.JsonDSL._
     
     //TODO: There must be a better way :(
     a match {
       case s: String => s
-      case l: Long => l
-      case i: Int => i
-      case d: Double => d
-      case f: Float => f
-      case bd: BigDecimal => bd
+      case Number(jv) => jv
       case b: Boolean => b
       case None => JNull
       case Some(value) => toJValue(value)

--- a/src/test/scala/loamstream/drm/DrmJobWrapperTest.scala
+++ b/src/test/scala/loamstream/drm/DrmJobWrapperTest.scala
@@ -305,7 +305,6 @@ final class DrmJobWrapperTest extends FunSuite {
                          |echo "Raw_Logs: .loamstream/${drmConfig.drmSystem.name.toLowerCase}/${jobName}/$${i}.{stdout,stderr}" >> $$STATS_FILE
                          |
                          |START="$$(date +%Y-%m-%dT%H:%M:%S)"
-                         |echo "Start: $$START" >> $$STATS_FILE
                          |
                          |`which time` -o $$STATS_FILE --format="ExitCode: %x\\nMemory: %Mk\\nSystem: %Ss\\nUser: %Us" bash $$COMMAND_SCRIPT 1> $$STDOUT_FILE 2> $$STDERR_FILE
                          |
@@ -313,6 +312,7 @@ final class DrmJobWrapperTest extends FunSuite {
                          |
                          |echo "$$LOAMSTREAM_JOB_EXIT_CODE" > $$EXITCODE_FILE
                          |
+                         |echo "Start: $$START" >> $$STATS_FILE
                          |echo "End: $$(date +%Y-%m-%dT%H:%M:%S)" >> $$STATS_FILE
                          |
                          |exit $$LOAMSTREAM_JOB_EXIT_CODE

--- a/src/test/scala/loamstream/drm/RateLimitedPollerTest.scala
+++ b/src/test/scala/loamstream/drm/RateLimitedPollerTest.scala
@@ -42,31 +42,4 @@ final class RateLimitedPollerTest extends FunSuite {
       assert(actual === expected)
     }
   }
-   /*private[drm] def readExitCodeFromStatsFile(file: Path): Option[DrmStatus] = {
-    trace(s"Reading from $file")
-    
-    CanBeClosed.using(Source.fromFile(file.toFile)) { source =>
-      val lines: Iterator[String] = source.getLines.map(_.trim).filter(_.nonEmpty)
-      
-      val exitCodes: Iterator[Int] = lines.collectFirst {
-        case RateLimitedPoller.Regexes.exitCodeInStatsFile(ec) => ec.toInt
-      }.iterator
-
-      toStatusOpt(exitCodes)
-    }
-  }
-
-  private[drm] def readExitCodeFromExitCodeFile(file: Path): Option[DrmStatus] = {
-    trace(s"Reading from $file")
-
-    CanBeClosed.using(Source.fromFile(file.toFile)) { source =>
-      val lines: Iterator[String] = source.getLines.map(_.trim).filter(_.nonEmpty)
-      
-      val exitCodes: Iterator[Int] = {
-        lines.map(line => Try(line.toInt).get)
-      }
-
-      toStatusOpt(exitCodes)
-    }
-  }*/
 }

--- a/src/test/scala/loamstream/drm/RateLimitedPollerTest.scala
+++ b/src/test/scala/loamstream/drm/RateLimitedPollerTest.scala
@@ -1,0 +1,72 @@
+package loamstream.drm
+
+import org.scalatest.FunSuite
+import loamstream.TestHelpers
+import loamstream.util.Files
+import loamstream.util.LogContext
+import breeze.numerics.exp
+
+/**
+  * @author clint
+  * @date Sep 29, 2021
+  */
+final class RateLimitedPollerTest extends FunSuite {
+  test("readExitCodeFromStatsFile") {
+    TestHelpers.withWorkDir(getClass.getSimpleName) { workDir => 
+      val statsFile = workDir.resolve("stats")
+
+      Files.writeTo(statsFile)("""|ExitCode: 42
+                                  |Memory: 4640888k
+                                  |System: 121.30s
+                                  |User: 638.37s
+                                  |End: 2021-09-29T16:14:20""".stripMargin)
+      
+      val actual = RateLimitedPoller.readExitCodeFromStatsFile(statsFile)(LogContext.Noop)
+
+      val expected = Some(DrmStatus.CommandResult(42))
+
+      assert(actual === expected)
+    }
+  }
+
+  test("readExitCodeFromExitCodeFile") {
+    TestHelpers.withWorkDir(getClass.getSimpleName) { workDir => 
+      val statsFile = workDir.resolve("stats")
+
+      Files.writeTo(statsFile)("42")
+      
+      val actual = RateLimitedPoller.readExitCodeFromExitCodeFile(statsFile)(LogContext.Noop)
+
+      val expected = Some(DrmStatus.CommandResult(42))
+
+      assert(actual === expected)
+    }
+  }
+   /*private[drm] def readExitCodeFromStatsFile(file: Path): Option[DrmStatus] = {
+    trace(s"Reading from $file")
+    
+    CanBeClosed.using(Source.fromFile(file.toFile)) { source =>
+      val lines: Iterator[String] = source.getLines.map(_.trim).filter(_.nonEmpty)
+      
+      val exitCodes: Iterator[Int] = lines.collectFirst {
+        case RateLimitedPoller.Regexes.exitCodeInStatsFile(ec) => ec.toInt
+      }.iterator
+
+      toStatusOpt(exitCodes)
+    }
+  }
+
+  private[drm] def readExitCodeFromExitCodeFile(file: Path): Option[DrmStatus] = {
+    trace(s"Reading from $file")
+
+    CanBeClosed.using(Source.fromFile(file.toFile)) { source =>
+      val lines: Iterator[String] = source.getLines.map(_.trim).filter(_.nonEmpty)
+      
+      val exitCodes: Iterator[Int] = {
+        lines.map(line => Try(line.toInt).get)
+      }
+
+      toStatusOpt(exitCodes)
+    }
+  }*/
+}

--- a/src/test/scala/loamstream/drm/ScriptBuilderTest.scala
+++ b/src/test/scala/loamstream/drm/ScriptBuilderTest.scala
@@ -254,7 +254,6 @@ echo DRM_Task_Id: "$${jobId}-$${i}" >> $$STATS_FILE
 echo "Raw_Logs: .loamstream/${drmSystem.name.toLowerCase}/${jobName}/$${i}.{stdout,stderr}" >> $$STATS_FILE
 
 START="$$(date +%Y-%m-%dT%H:%M:%S)"
-echo "Start: $$START" >> $$STATS_FILE
 
 `which time` -o $$STATS_FILE --format="ExitCode: %x\\nMemory: %Mk\\nSystem: %Ss\\nUser: %Us" bash $$COMMAND_SCRIPT 1> $$STDOUT_FILE 2> $$STDERR_FILE
 
@@ -262,6 +261,7 @@ LOAMSTREAM_JOB_EXIT_CODE=$$?
 
 echo "$$LOAMSTREAM_JOB_EXIT_CODE" > $$EXITCODE_FILE
 
+echo "Start: $$START" >> $$STATS_FILE
 echo "End: $$(date +%Y-%m-%dT%H:%M:%S)" >> $$STATS_FILE
 
 exit $$LOAMSTREAM_JOB_EXIT_CODE
@@ -283,7 +283,6 @@ echo DRM_Task_Id: "$${jobId}-$${i}" >> $$STATS_FILE
 echo "Raw_Logs: .loamstream/${drmSystem.name.toLowerCase}/${jobName}/$${i}.{stdout,stderr}" >> $$STATS_FILE
 
 START="$$(date +%Y-%m-%dT%H:%M:%S)"
-echo "Start: $$START" >> $$STATS_FILE
 
 `which time` -o $$STATS_FILE --format="ExitCode: %x\\nMemory: %Mk\\nSystem: %Ss\\nUser: %Us" bash $$COMMAND_SCRIPT 1> $$STDOUT_FILE 2> $$STDERR_FILE
 
@@ -291,6 +290,7 @@ LOAMSTREAM_JOB_EXIT_CODE=$$?
 
 echo "$$LOAMSTREAM_JOB_EXIT_CODE" > $$EXITCODE_FILE
 
+echo "Start: $$START" >> $$STATS_FILE
 echo "End: $$(date +%Y-%m-%dT%H:%M:%S)" >> $$STATS_FILE
 
 exit $$LOAMSTREAM_JOB_EXIT_CODE
@@ -312,7 +312,6 @@ echo DRM_Task_Id: "$${jobId}-$${i}" >> $$STATS_FILE
 echo "Raw_Logs: .loamstream/${drmSystem.name.toLowerCase}/${jobName}/$${i}.{stdout,stderr}" >> $$STATS_FILE
 
 START="$$(date +%Y-%m-%dT%H:%M:%S)"
-echo "Start: $$START" >> $$STATS_FILE
 
 `which time` -o $$STATS_FILE --format="ExitCode: %x\\nMemory: %Mk\\nSystem: %Ss\\nUser: %Us" bash $$COMMAND_SCRIPT 1> $$STDOUT_FILE 2> $$STDERR_FILE
 
@@ -320,6 +319,7 @@ LOAMSTREAM_JOB_EXIT_CODE=$$?
 
 echo "$$LOAMSTREAM_JOB_EXIT_CODE" > $$EXITCODE_FILE
 
+echo "Start: $$START" >> $$STATS_FILE
 echo "End: $$(date +%Y-%m-%dT%H:%M:%S)" >> $$STATS_FILE
 
 exit $$LOAMSTREAM_JOB_EXIT_CODE

--- a/src/test/scala/loamstream/googlecloud/GoogleCloudChunkRunnerTest.scala
+++ b/src/test/scala/loamstream/googlecloud/GoogleCloudChunkRunnerTest.scala
@@ -26,19 +26,17 @@ import scala.collection.compat._
 import loamstream.util.Maps
 import loamstream.util.Observables
 
+import GoogleCloudChunkRunnerTest.LiteralMockDataProcClient
+import GoogleCloudChunkRunnerTest.MockDataProcClient
+import loamstream.TestHelpers.waitForT
+import loamstream.util.Observables.Implicits._
+import monix.execution.Scheduler.Implicits.global
 
 /**
  * @author clint
  * Dec 15, 2016
  */
 final class GoogleCloudChunkRunnerTest extends FunSuite with ProvidesEnvAndResources {
-  
-  import GoogleCloudChunkRunnerTest.LiteralMockDataProcClient
-  import GoogleCloudChunkRunnerTest.MockDataProcClient
-  import loamstream.TestHelpers.waitForT
-  import loamstream.util.Observables.Implicits._
-  import monix.execution.Scheduler.Implicits.global
-
   private val clusterId = "some-cluster-id"
   
   private val googleConfig = {
@@ -109,7 +107,7 @@ final class GoogleCloudChunkRunnerTest extends FunSuite with ProvidesEnvAndResou
   }
   
   test("withCluster") {
-    import Observables.Implicits._
+    
     
     withMockRunner { (_, googleRunner, mockClient) =>
       assert(googleRunner.singleThreadedExecutor.isShutdown === false)
@@ -671,8 +669,6 @@ final class GoogleCloudChunkRunnerTest extends FunSuite with ProvidesEnvAndResou
   }
   
   test("startClusterIfNecessary - error starting cluster") {
-    import GoogleCloudChunkRunnerTest.LiteralMockDataProcClient
-    
     withMockClient { delegateClient =>
       val client = new LiteralMockDataProcClient(
           delegate = delegateClient, 


### PR DESCRIPTION
Merge some outstanding BCH-Slurm-related work with the code that worked in the end (to the best of my knowledge).  Changes:
- Don't read from `stats` files when determining exit status for jobs, only use `exitcode` files.  
- Get tests passing.