### PR TITLE
Rk fix gc cluster deletion hang

### DIFF
--- a/src/main/scala/loamstream/googlecloud/CloudSdkDataProcWrapper.scala
+++ b/src/main/scala/loamstream/googlecloud/CloudSdkDataProcWrapper.scala
@@ -65,8 +65,8 @@ object CloudSdkDataProcWrapper extends Loggable {
   private[googlecloud] def gcloudTokens(config: GoogleCloudConfig)(verb: String)(args: String*): Seq[String] = {
     val gcloud = normalize(config.gcloudBinary)
 
-    gcloud +: "beta" +: "dataproc" +: "clusters" +: verb +: "--project" +: config.projectId +: 
-    "--region" +: config.region +: args +: "--quiet"
+    gcloud +: "beta" +: "dataproc" +: "clusters" +: verb +: "--quiet" +: "--project" +: config.projectId +: 
+    "--region" +: config.region +: args
   }
 
   private def runCommand(tokens: Seq[String]): Int = runProcess(tokens.mkString(" "), "Google Cloud SDK")

--- a/src/main/scala/loamstream/googlecloud/CloudSdkDataProcWrapper.scala
+++ b/src/main/scala/loamstream/googlecloud/CloudSdkDataProcWrapper.scala
@@ -66,7 +66,7 @@ object CloudSdkDataProcWrapper extends Loggable {
     val gcloud = normalize(config.gcloudBinary)
 
     gcloud +: "beta" +: "dataproc" +: "clusters" +: verb +: "--project" +: config.projectId +: 
-    "--region" +: config.region +: args
+    "--region" +: config.region +: args +: "--quiet"
   }
 
   private def runCommand(tokens: Seq[String]): Int = runProcess(tokens.mkString(" "), "Google Cloud SDK")


### PR DESCRIPTION
The Google Cloud SDK gcloud delete command was hanging up because it asked for user input (Y/N) and waited for it indefinitely. Adding the --quiet flag led to successful google cloud cluster deletion.